### PR TITLE
Improve designer fallbacks and assets

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -3,6 +3,7 @@ import json
 import random
 import logging
 from datetime import datetime
+from pathlib import Path
 from typing import Dict, Any
 from urllib.parse import quote
 
@@ -205,7 +206,10 @@ async def build_render_data(device: str = "familydisplay") -> dict:
     now = datetime.now()
     date_str = now.strftime("%a, %d %b")
     
-    svg_base = make_public_url("gcs/assets/svgs")
+    if storage_enabled:
+        svg_base = make_public_url("gcs/assets/svgs")
+    else:
+        svg_base = make_public_url("designer/svgs")
     
     return {
         "layout": layout,
@@ -345,41 +349,89 @@ def get_gcs_asset(path: str):
         }
     )
 
+def _discover_local_svgs() -> list[str]:
+    search_dirs = [
+        Path("backend/web/designer/svgs"),
+        Path("web/designer/svgs"),
+        Path("web/svgs"),
+    ]
+    for directory in search_dirs:
+        if directory.exists():
+            svgs = sorted([p.name for p in directory.glob("*.svg")])
+            if svgs:
+                return svgs
+    return []
+
+
 @app.get("/api/list-svgs")
 def list_svgs():
-    """List all SVG files in GCS bucket"""
-    if not storage_enabled:
-        return {"svgs": []}
-    
-    try:
-        blobs = gcs_bucket.list_blobs(prefix="assets/svgs/")
-        svgs = [
-            blob.name.split("/")[-1]
-            for blob in blobs
-            if blob.name.endswith(".svg")
-        ]
-        logger.info(f"Found {len(svgs)} SVGs in bucket")
-        return {"svgs": svgs}
-    except Exception as e:
-        logger.error(f"Failed to list SVGs: {e}")
-        return {"svgs": []}
+    """List all SVG files available to the designer"""
+    svgs: list[str] = []
+    base_url = None
+
+    if storage_enabled:
+        try:
+            blobs = gcs_bucket.list_blobs(prefix="assets/svgs/")
+            svgs = [
+                blob.name.split("/")[-1]
+                for blob in blobs
+                if blob.name.endswith(".svg")
+            ]
+            if svgs:
+                base_url = "/gcs/assets/svgs"
+                logger.info(f"Found {len(svgs)} SVGs in bucket")
+        except Exception as e:
+            logger.error(f"Failed to list SVGs from GCS: {e}")
+
+    if not svgs:
+        svgs = _discover_local_svgs()
+        if svgs:
+            base_url = "/designer/svgs"
+            logger.info(f"Using {len(svgs)} local SVGs")
+
+    return {"svgs": svgs, "base_url": base_url}
+
+
+def _discover_local_weather_themes() -> list[str]:
+    base_dir = Path("backend/web/designer/weather-icons")
+    if not base_dir.exists():
+        return []
+    return sorted([p.name for p in base_dir.iterdir() if p.is_dir()])
+
 
 @app.get("/api/list-weather-themes")
 def list_weather_themes():
     """List available weather icon themes"""
-    if not storage_enabled:
-        return {"themes": ["happy-skies", "soft-skies", "sunny-day", "blue-sky-pro"]}
-    
-    try:
-        blobs = gcs_bucket.list_blobs(prefix="assets/weather-icons/", delimiter="/")
-        themes = [
-            prefix.split("/")[-2]
-            for prefix in blobs.prefixes
-        ]
-        return {"themes": themes}
-    except Exception as e:
-        logger.error(f"Failed to list weather themes: {e}")
-        return {"themes": ["happy-skies", "soft-skies", "sunny-day", "blue-sky-pro"]}
+    themes: list[str] = []
+    icon_base = None
+
+    if storage_enabled:
+        try:
+            blobs = gcs_bucket.list_blobs(prefix="assets/weather-icons/", delimiter="/")
+            prefixes: list[str] = []
+            for page in blobs.pages:
+                prefixes.extend(page.prefixes)
+            themes = [
+                prefix.rstrip("/").split("/")[-1]
+                for prefix in prefixes
+            ]
+            if themes:
+                icon_base = "/gcs/assets/weather-icons"
+        except Exception as e:
+            logger.error(f"Failed to list weather themes from GCS: {e}")
+
+    if not themes:
+        themes = _discover_local_weather_themes()
+        if themes:
+            icon_base = "/designer/weather-icons"
+
+    if not themes:
+        themes = ["happy-skies", "soft-skies", "sunny-day", "blue-sky-pro"]
+
+    if icon_base is None:
+        icon_base = "/gcs/assets/weather-icons" if storage_enabled else "/designer/weather-icons"
+
+    return {"themes": themes, "icon_base": icon_base}
 
 @app.get("/layouts/{device}")
 def get_layout(device: str, x_admin_token: str = Header(None)):
@@ -512,6 +564,27 @@ if os.path.exists("web/presets"):
 
 if os.path.exists("web/svgs"):
     app.mount("/svgs", StaticFiles(directory="web/svgs"), name="svgs")
+
+if os.path.exists("backend/web/designer/presets"):
+    app.mount(
+        "/designer/presets",
+        StaticFiles(directory="backend/web/designer/presets", html=True),
+        name="designer-presets",
+    )
+
+if os.path.exists("backend/web/designer/svgs"):
+    app.mount(
+        "/designer/svgs",
+        StaticFiles(directory="backend/web/designer/svgs"),
+        name="designer-svgs",
+    )
+
+if os.path.exists("backend/web/designer/weather-icons"):
+    app.mount(
+        "/designer/weather-icons",
+        StaticFiles(directory="backend/web/designer/weather-icons"),
+        name="designer-weather-icons",
+    )
 
 if __name__ == "__main__":
     import uvicorn

--- a/backend/web/designer/overlay_designer_v3_full.html
+++ b/backend/web/designer/overlay_designer_v3_full.html
@@ -236,8 +236,8 @@ header{
   position:relative;
   width:800px;
   height:480px;
-  /* Removed !important, this gradient is correct */
-  background:linear-gradient(135deg, #f5f7fa 0%, #c3cfe2 100%);
+  /* Refreshed canvas palette for a softer designer backdrop */
+  background:linear-gradient(135deg, #1f1c2c 0%, #514a9d 40%, #24c6dc 100%);
   border:1px solid var(--border);
   box-shadow:0 10px 40px rgba(0,0,0,0.3);
   overflow:hidden;
@@ -293,12 +293,14 @@ header{
   background:rgba(255,255,255,0.1);
   border-radius:12px;
 }
-.el.svg-overlay{
+.el.svg-overlay,
+.el.svg{
   display:flex;
   align-items:center;
   justify-content:center;
 }
-.el.svg-overlay svg{
+.el.svg-overlay svg,
+.el.svg svg{
   width:100%;
   height:100%;
   object-fit:contain;
@@ -616,7 +618,6 @@ button:disabled:hover {
 
     <div class="divider"></div>
 
-    <button id="editSettingsBtn" class="tiny">⚙️ Settings</button>
     <button id="undoBtn" class="tiny">↶ Undo</button>
     <button id="redoBtn" class="tiny">↷ Redo</button>
 
@@ -680,6 +681,7 @@ button:disabled:hover {
             <button id="loadBtn" style="flex:1">📥 Load</button>
           </div>
           <div id="syncStatus" style="font-size:11px;color:var(--muted);margin-top:8px;text-align:center"></div>
+          <button id="editSettingsBtn" class="tiny" style="width:100%;margin-top:8px">⚙️ Settings</button>
         </div>
       </div>
 
@@ -909,6 +911,7 @@ button:disabled:hover {
 <script>
 // --- Globals ---
 const GRID_SIZE = 20;
+const FORCE_SETUP_ON_LOAD = true;
 const canvas = document.getElementById('canvas');
 const gridOverlay = document.getElementById('gridOverlay');
 const templateSelect = document.getElementById('templateSelect');
@@ -944,6 +947,9 @@ let availablePresets = [];
 let availableSVGs = [];
 let availableInfoTypes = [];
 let renderData = null;
+let svgLibraryBase = '/gcs/assets/svgs';
+let weatherIconBase = '/gcs/assets/weather-icons';
+const FALLBACK_WEATHER_ICON = '/designer/svgs/weather_card_blue.svg';
 
 // --- Setup Modal Logic ---
 function showSetupModal() {
@@ -1017,7 +1023,9 @@ document.getElementById('setupTogglePasskey').addEventListener('click', () => {
 document.getElementById('editSettingsBtn').addEventListener('click', showSetupModal);
 
 function checkSetupNeeded() {
-  if (!storedDeviceId || !storedAdminToken) {
+  if (FORCE_SETUP_ON_LOAD) {
+    setTimeout(showSetupModal, 400);
+  } else if (!storedDeviceId || !storedAdminToken) {
     setTimeout(showSetupModal, 500);
   }
   updateDeviceStatusUI();
@@ -1035,7 +1043,7 @@ function snap(val) {
 function setStatus(msg, timeout = 0, isError = false) {
   statusText.textContent = msg;
   statusText.classList.toggle('error', isError);
-  
+
   if (timeout > 0) {
     setTimeout(() => {
       statusText.textContent = 'Ready';
@@ -1080,6 +1088,19 @@ function drawGrid() {
   }
 }
 
+function buildSvgUrl(svgName) {
+  if (!svgName) return '';
+  if (svgName.startsWith('http://') || svgName.startsWith('https://')) return svgName;
+  const base = (svgLibraryBase || '/gcs/assets/svgs').replace(/\/$/, '');
+  return `${base}/${svgName.replace(/^\//, '')}`;
+}
+
+function buildWeatherIconUrl(theme, code = '01d') {
+  const safeTheme = theme || 'happy-skies';
+  const base = (weatherIconBase || '/gcs/assets/weather-icons').replace(/\/$/, '');
+  return `${base}/${safeTheme}/${code}.svg`;
+}
+
 // --- Data Fetching ---
 async function fetchRenderData() {
   try {
@@ -1088,7 +1109,10 @@ async function fetchRenderData() {
     const response = await fetch(`/v1/render_data?device=${device}`);
     if (!response.ok) throw new Error(`Server error: ${response.status}`);
     renderData = await response.json();
-    
+    if (renderData.svg_base) {
+      svgLibraryBase = renderData.svg_base;
+    }
+
     availableInfoTypes = ['CUSTOM'];
     if (renderData.weather) {
       availableInfoTypes.push('TEMP', 'FEELS_LIKE', 'HUMIDITY', 'RAIN', 'WIND', 'WEATHER_DESC', 'CITY');
@@ -1369,10 +1393,11 @@ function stopResize() {
 // --- Element Creation ---
 function addElement(kind, x, y, w, h, options = {}) {
   console.log('addElement called:', kind, x, y, w, h, options);
-  saveAction(`Add ${kind}`);
-  
+  const actualKind = kind === 'svg' ? 'svg-overlay' : kind;
+  saveAction(`Add ${actualKind}`);
+
   const el = document.createElement('div');
-  el.className = 'el ' + kind;
+  el.className = 'el ' + actualKind;
   el.style.left = snap(x) + 'px';
   el.style.top = snap(y) + 'px';
   el.style.width = w + 'px';
@@ -1381,7 +1406,7 @@ function addElement(kind, x, y, w, h, options = {}) {
   el.style.zIndex = '10'; // All elements on same z-index, selection outline handles visibility
   el.dataset.rotation = options.rotation || 0;
   
-  if (kind === 'text' || kind === 'icon') {
+  if (actualKind === 'text' || actualKind === 'icon') {
     const content = document.createElement('div');
     content.className = 'el-content';
     content.textContent = options.text || 'Text';
@@ -1397,7 +1422,7 @@ function addElement(kind, x, y, w, h, options = {}) {
     el.appendChild(content);
     applyTextShadow(content);
     console.log('Created text/icon element with content:', content.textContent);
-  } else if (kind === 'box') {
+  } else if (actualKind === 'box') {
     el.style.backgroundColor = options.bgColor || 'rgba(255,255,255,0.16)';
     el.style.borderColor = options.borderColor || 'rgba(0,0,0,0.2)';
     el.style.borderWidth = (options.borderWidth || 1) + 'px';
@@ -1408,7 +1433,7 @@ function addElement(kind, x, y, w, h, options = {}) {
     el.dataset.boxShadowIntensity = options.boxShadowIntensity || 1;
     applyBoxShadow(el);
     console.log('Created box element');
-  } else if (kind === 'svg-overlay') {
+  } else if (actualKind === 'svg-overlay') {
     el.innerHTML = options.svgContent || '<svg></svg>';
     el.dataset.fillType = options.fillType || 'none';
     el.dataset.fillColor = options.fillColor || '#2d8cf0';
@@ -1564,7 +1589,7 @@ function redo() {
 
 // --- Presets, SVGs, Themes (API) ---
 async function loadPresets() {
-  const paths = ['/presets/', '/web/presets/'];
+  const paths = ['/presets/', '/web/presets/', '/designer/presets/'];
   
   for (const path of paths) {
     try {
@@ -1594,8 +1619,7 @@ async function loadPresets() {
   console.warn('No presets found in any path');
   availablePresets = [];
   renderPresetOptions();
-  // Rethrow to be caught by init()
-  throw new Error('Failed to load presets.');
+  setStatus('No presets available locally', 2000, true);
 }
 
 function renderPresetOptions() {
@@ -1619,7 +1643,7 @@ function renderPresetOptions() {
 async function applyTemplate(key) {
   if (!key) return;
   
-  const paths = [`/presets/${key}.json`, `/web/presets/${key}.json`];
+  const paths = [`/presets/${key}.json`, `/web/presets/${key}.json`, `/designer/presets/${key}.json`];
   
   for (const path of paths) {
     try {
@@ -1646,9 +1670,13 @@ async function loadWeatherThemes() {
   try {
     const response = await fetch('/api/list-weather-themes');
     if (!response.ok) throw new Error('Failed to list weather themes');
-    
+
     const data = await response.json();
-    const themes = data.themes || ['happy-skies', 'soft-skies', 'sunny-day', 'blue-sky-pro'];
+    weatherIconBase = data.icon_base || weatherIconBase;
+    let themes = data.themes || [];
+    if (!themes.length) {
+      themes = ['happy-skies', 'soft-skies', 'sunny-day', 'blue-sky-pro'];
+    }
     
     const themeEmojis = {
       'happy-skies': '😊',
@@ -1679,11 +1707,25 @@ async function loadWeatherThemes() {
       selector.appendChild(item);
     });
     
-    console.log('Loaded weather themes:', themes);
+    console.log('Loaded weather themes:', themes, 'base:', weatherIconBase);
     document.getElementById('quickAddIcon').disabled = false;
   } catch (error) {
     console.error('Failed to load weather themes:', error);
-    throw new Error('Failed to load weather themes.');
+    weatherIconBase = '/designer/weather-icons';
+    const fallbackThemes = ['happy-skies', 'soft-skies', 'sunny-day', 'blue-sky-pro'];
+    const selector = document.getElementById('weatherThemeSelector');
+    selector.innerHTML = '';
+    fallbackThemes.forEach(theme => {
+      const item = document.createElement('div');
+      item.className = 'selector-item';
+      item.dataset.theme = theme;
+      item.innerHTML = `
+        <div class="selector-item-icon">🌤</div>
+        <div class="selector-item-label">${theme}</div>
+      `;
+      selector.appendChild(item);
+    });
+    document.getElementById('quickAddIcon').disabled = false;
   }
 }
 
@@ -1691,31 +1733,36 @@ async function loadSVGLibrary() {
   try {
     const response = await fetch('/api/list-svgs');
     if (!response.ok) throw new Error('Failed to list SVGs');
-    
+
     const data = await response.json();
+    svgLibraryBase = data.base_url || svgLibraryBase;
     availableSVGs = data.svgs || [];
-    
+
     if (availableSVGs.length === 0) {
-      throw new Error('No SVGs found in bucket');
+      console.warn('No SVGs reported by API; fallback quick-add disabled.');
+      document.getElementById('quickAddFancyBox').disabled = true;
+      return;
     }
-    
-    console.log(`Found ${availableSVGs.length} SVGs`);
+
+    console.log(`Found ${availableSVGs.length} SVGs (base: ${svgLibraryBase})`);
     document.getElementById('quickAddFancyBox').disabled = false;
   } catch (error) {
     console.error('Failed to load SVG library:', error);
     availableSVGs = [];
-    throw new Error('Failed to load SVG library.');
+    // Do not rethrow so init can continue with other data
   }
 }
 
 // --- Import/Export & Save/Load ---
 function exportToJSON() {
   const elements = Array.from(canvas.querySelectorAll('.el')).map(el => {
-    const base = {
-      kind: el.classList.contains('text') ? 'text' :
+    const domKind = el.classList.contains('text') ? 'text' :
             el.classList.contains('icon') ? 'icon' :
             el.classList.contains('box') ? 'box' :
-            el.classList.contains('svg-overlay') ? 'svg-overlay' : 'unknown',
+            el.classList.contains('svg-overlay') ? 'svg-overlay' : 'unknown';
+
+    const base = {
+      kind: domKind,
       x: parsePx(el.style.left),
       y: parsePx(el.style.top),
       w: parsePx(el.style.width),
@@ -1723,15 +1770,15 @@ function exportToJSON() {
       rotation: parseFloat(el.dataset.rotation || 0),
       opacity: parseFloat(el.style.opacity || 1)
     };
-    
-    if (base.kind === 'text' || base.kind === 'icon') {
+
+    if (domKind === 'text' || domKind === 'icon') {
       const content = el.querySelector('.el-content');
       const style = getComputedStyle(content);
       base.text = getElText(el);
       base.type = el.dataset.type || 'CUSTOM';
       base.fontSize = parsePx(style.fontSize);
       base.color = rgbToHex(style.color);
-      base.fontFamily = el.style.fontFamily.replace(/['"]/g, '');
+      base.fontFamily = (el.style.fontFamily || style.fontFamily || 'Inter').replace(/['"]/g, '');
       base.weight = style.fontWeight;
       base.align = style.textAlign;
       base.textShadowType = el.dataset.textShadowType || 'none';
@@ -1739,19 +1786,35 @@ function exportToJSON() {
         base.textShadowColor = el.dataset.textShadowColor;
         base.textShadowIntensity = parseFloat(el.dataset.textShadowIntensity || 1);
       }
-    } else if (base.kind === 'box') {
-      base.bgColor = rgbToHex(el.style.backgroundColor);
-      base.borderColor = rgbToHex(el.style.borderColor);
-      base.borderWidth = parsePx(el.style.borderWidth);
-      base.borderRadius = parsePx(el.style.borderRadius);
+    } else if (domKind === 'box') {
+      const style = getComputedStyle(el);
+      base.fill = style.backgroundColor && style.backgroundColor !== 'rgba(0, 0, 0, 0)'
+        ? style.backgroundColor
+        : 'transparent';
+      const borderWidth = parsePx(style.borderWidth);
+      if (borderWidth > 0) {
+        const borderColor = style.borderColor || '#000000';
+        base.border = `${borderWidth}px solid ${borderColor}`;
+      }
+      base.radius = parsePx(style.borderRadius);
+      base.bgColor = base.fill;
+      base.borderColor = style.borderColor || '#000000';
+      base.borderWidth = borderWidth;
+      base.borderRadius = base.radius;
       base.boxShadowType = el.dataset.boxShadowType || 'none';
       if (base.boxShadowType !== 'none') {
         base.boxShadowColor = el.dataset.boxShadowColor;
         base.boxShadowIntensity = parseFloat(el.dataset.boxShadowIntensity || 1);
       }
-    } else if (base.kind === 'svg-overlay') {
+      if (style.boxShadow && style.boxShadow !== 'none') {
+        base.shadow = style.boxShadow;
+      }
+    } else if (domKind === 'svg-overlay') {
       // Don't save the full modified SVG, just the name and options
-      base.svgName = el.dataset.svgName || 'svg';
+      const svgName = el.dataset.svgName || 'svg';
+      base.kind = 'svg';
+      base.svgName = svgName;
+      base.src = svgName;
       base.fillType = el.dataset.fillType || 'none';
       if (base.fillType === 'solid') {
         base.fillColor = el.dataset.fillColor;
@@ -1761,9 +1824,9 @@ function exportToJSON() {
         base.gradAngle = parseFloat(el.dataset.gradAngle || 135);
       }
       // svgContent will be re-fetched on load
-      delete base.svgContent; 
+      delete base.svgContent;
     }
-    
+
     return base;
   });
   
@@ -1787,33 +1850,45 @@ async function loadFromJSON(data) {
   }
   
   const elementPromises = (data.elements || []).map(async (elem) => {
+    const elementKind = elem.kind === 'svg-overlay' ? 'svg' : elem.kind;
     const options = { ...elem };
-    
-    // Re-fetch SVG content if it's an svg-overlay
-    if (elem.kind === 'svg-overlay' && elem.svgName) {
-      if (elem.svgName.startsWith('weather-')) {
-        // Handle weather icon placeholder
-        const theme = elem.svgName.split('-')[1] || 'happy-skies';
-        const svgUrl = `/gcs/assets/weather-icons/${theme}/01d.svg`;
+
+    if (elementKind === 'svg') {
+      const svgName = elem.svgName || elem.src || '';
+      options.svgName = svgName;
+
+      try {
+        let svgUrl = '';
+        if (svgName && svgName.startsWith('weather-')) {
+          const theme = svgName.replace('weather-', '') || 'happy-skies';
+          svgUrl = buildWeatherIconUrl(theme);
+        } else {
+          svgUrl = buildSvgUrl(svgName);
+        }
+
+        if (svgUrl) {
+          const response = await fetch(svgUrl);
+          if (response.ok) {
+            options.svgContent = await response.text();
+          }
+        }
+      } catch (error) {
+        console.warn('Failed to hydrate SVG element', svgName, error);
+      }
+
+      if (!options.svgContent && FALLBACK_WEATHER_ICON) {
         try {
-          const response = await fetch(svgUrl);
-          if (response.ok) {
-            options.svgContent = await response.text();
+          const fallbackResponse = await fetch(FALLBACK_WEATHER_ICON);
+          if (fallbackResponse.ok) {
+            options.svgContent = await fallbackResponse.text();
           }
-        } catch(e) { console.error('Failed to load weather icon placeholder'); }
-      } else {
-        // Handle regular SVG
-        const svgUrl = `/gcs/assets/svgs/${elem.svgName}`;
-         try {
-          const response = await fetch(svgUrl);
-          if (response.ok) {
-            options.svgContent = await response.text();
-          }
-        } catch(e) { console.error(`Failed to load SVG: ${elem.svgName}`); }
+        } catch (fallbackError) {
+          console.warn('Fallback SVG load failed', fallbackError);
+        }
       }
     }
-    
-    addElement(elem.kind, elem.x, elem.y, elem.w, elem.h, options);
+
+    addElement(elementKind, elem.x, elem.y, elem.w, elem.h, options);
   });
   
   await Promise.all(elementPromises);
@@ -1908,8 +1983,8 @@ document.getElementById('quickAddFancyBox').addEventListener('click', () => {
       item.dataset.svg = svgName;
       item.innerHTML = '<div style="font-size:10px;opacity:0.5">...</div>';
       
-      const svgUrl = `/gcs/assets/svgs/${svgName}`;
-      
+      const svgUrl = buildSvgUrl(svgName);
+
       fetch(svgUrl)
         .then(r => r.ok ? r.text() : Promise.reject())
         .then(svgContent => {
@@ -1923,11 +1998,11 @@ document.getElementById('quickAddFancyBox').addEventListener('click', () => {
           label.className = 'selector-item-label';
           label.textContent = svgName.replace('.svg', '');
           item.appendChild(label);
-          
+
           item.addEventListener('click', () => {
-            addElement('svg-overlay', 100, 100, 100, 100, {
-              svgContent: svgContent,
-              svgName: svgName,
+            addElement('svg', 100, 100, 100, 100, {
+              svgContent,
+              svgName,
               fillType: 'none'
             });
             modal.classList.add('hidden');
@@ -2030,25 +2105,35 @@ document.getElementById('quickAddIcon').addEventListener('click', async () => {
     item.replaceWith(newItem);
     
     newItem.addEventListener('click', async () => {
-      const svgUrl = `/gcs/assets/weather-icons/${theme}/01d.svg`;
-      
+      const svgUrl = buildWeatherIconUrl(theme);
+
       try {
-        const response = await fetch(svgUrl);
-        if (response.ok) {
-          const svgContent = await response.text();
-          
-          addElement('svg-overlay', 100, 100, 120, 120, {
-            svgContent: svgContent,
-            svgName: `weather-${theme}`, // Special name for reloading
-            fillType: 'none'
-          });
-          
-          modal.classList.add('hidden');
-          setStatus(`Added weather icon: ${theme}`, 1500);
-          return;
-        } else {
-          throw new Error(`Icon not found: ${response.status}`);
+        let svgContent = '';
+        try {
+          const response = await fetch(svgUrl);
+          if (response.ok) {
+            svgContent = await response.text();
+          } else {
+            throw new Error(`HTTP ${response.status}`);
+          }
+        } catch (networkError) {
+          console.warn('Weather icon fetch failed, using fallback', networkError);
+          const fallbackResponse = await fetch(FALLBACK_WEATHER_ICON);
+          if (fallbackResponse.ok) {
+            svgContent = await fallbackResponse.text();
+          } else {
+            throw new Error('Fallback icon not available');
+          }
         }
+
+        addElement('svg', 100, 100, 120, 120, {
+          svgContent,
+          svgName: `weather-${theme}`,
+          fillType: 'none'
+        });
+
+        modal.classList.add('hidden');
+        setStatus(`Added weather icon: ${theme}`, 1500);
       } catch (error) {
         console.error('Failed to load weather icon:', error);
         setStatus(`Failed to load icon: ${error.message}`, 2000, true);

--- a/backend/web/designer/weather-icons/blue-sky-pro/01d.svg
+++ b/backend/web/designer/weather-icons/blue-sky-pro/01d.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 96 96">
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#1a2a6c" />
+      <stop offset="50%" stop-color="#b21f1f" />
+      <stop offset="100%" stop-color="#fdbb2d" />
+    </linearGradient>
+    <linearGradient id="ray" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#ffe259" />
+      <stop offset="100%" stop-color="#ffa751" />
+    </linearGradient>
+  </defs>
+  <rect width="96" height="96" rx="22" fill="url(#bg)" />
+  <g transform="translate(48 48)">
+    <circle r="18" fill="#fff1b8" />
+    <g stroke="url(#ray)" stroke-width="5" stroke-linecap="round">
+      <line x1="0" y1="-32" x2="0" y2="-44" />
+      <line x1="0" y1="32" x2="0" y2="44" />
+      <line x1="32" y1="0" x2="44" y2="0" />
+      <line x1="-32" y1="0" x2="-44" y2="0" />
+      <line x1="26" y1="-26" x2="35" y2="-35" />
+      <line x1="-26" y1="26" x2="-35" y2="35" />
+      <line x1="26" y1="26" x2="35" y2="35" />
+      <line x1="-26" y1="-26" x2="-35" y2="-35" />
+    </g>
+  </g>
+</svg>

--- a/backend/web/designer/weather-icons/happy-skies/01d.svg
+++ b/backend/web/designer/weather-icons/happy-skies/01d.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 96 96">
+  <defs>
+    <radialGradient id="sunGlow" cx="50%" cy="50%" r="60%">
+      <stop offset="0%" stop-color="#fff6a1" />
+      <stop offset="70%" stop-color="#ffcf6f" />
+      <stop offset="100%" stop-color="#f9a602" />
+    </radialGradient>
+  </defs>
+  <rect width="96" height="96" rx="22" fill="#fef6e7" />
+  <g transform="translate(48 48)">
+    <circle r="22" fill="url(#sunGlow)" />
+    <g stroke="#f7a41d" stroke-width="4" stroke-linecap="round">
+      <line x1="0" y1="-34" x2="0" y2="-44" />
+      <line x1="0" y1="34" x2="0" y2="44" />
+      <line x1="34" y1="0" x2="44" y2="0" />
+      <line x1="-34" y1="0" x2="-44" y2="0" />
+      <line x1="24" y1="-24" x2="31" y2="-31" />
+      <line x1="-24" y1="24" x2="-31" y2="31" />
+      <line x1="24" y1="24" x2="31" y2="31" />
+      <line x1="-24" y1="-24" x2="-31" y2="-31" />
+    </g>
+  </g>
+</svg>

--- a/backend/web/designer/weather-icons/soft-skies/01d.svg
+++ b/backend/web/designer/weather-icons/soft-skies/01d.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 96 96">
+  <defs>
+    <linearGradient id="cloudGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.95" />
+      <stop offset="100%" stop-color="#d3e4ff" />
+    </linearGradient>
+  </defs>
+  <rect width="96" height="96" rx="22" fill="#f0f4ff" />
+  <g transform="translate(24 52)">
+    <ellipse cx="24" cy="12" rx="24" ry="12" fill="url(#cloudGrad)" />
+    <ellipse cx="48" cy="12" rx="22" ry="12" fill="url(#cloudGrad)" />
+    <ellipse cx="36" cy="6" rx="24" ry="12" fill="url(#cloudGrad)" />
+  </g>
+  <circle cx="66" cy="30" r="12" fill="#ffd485" />
+</svg>

--- a/backend/web/designer/weather-icons/sunny-day/01d.svg
+++ b/backend/web/designer/weather-icons/sunny-day/01d.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 96 96">
+  <defs>
+    <linearGradient id="skyGrad" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#6dd5fa" />
+      <stop offset="100%" stop-color="#2980b9" />
+    </linearGradient>
+  </defs>
+  <rect width="96" height="96" rx="22" fill="url(#skyGrad)" />
+  <g transform="translate(48 48)">
+    <circle r="20" fill="#f9f871" stroke="#f6d365" stroke-width="6" />
+  </g>
+  <g stroke="#f9f871" stroke-width="5" stroke-linecap="round">
+    <line x1="48" y1="14" x2="48" y2="6" />
+    <line x1="48" y1="82" x2="48" y2="90" />
+    <line x1="82" y1="48" x2="90" y2="48" />
+    <line x1="6" y1="48" x2="14" y2="48" />
+  </g>
+</svg>

--- a/backend/web/layouts/base.html
+++ b/backend/web/layouts/base.html
@@ -295,7 +295,7 @@
         // ============================================================
         // ICON/SVG ELEMENTS - CRITICAL FIX
         // ============================================================
-        else if (kind === "icon" || kind === "svg") {
+        else if (kind === "icon" || kind === "svg" || kind === "svg-overlay") {
           let src = el.src || "";
           
           // Special case: weather icon shorthand


### PR DESCRIPTION
## Summary
- add local fallbacks for SVG and weather theme listings so the designer works without GCS credentials
- refresh the designer canvas experience, relocate the settings action, and force the setup modal on load
- align exported layout JSON with the renderer and provide local placeholder weather icons

## Testing
- python -m compileall backend

------
https://chatgpt.com/codex/tasks/task_e_69088665ccf0832c9962fc19ed89e7ab