### PR TITLE
Add API endpoint for loading designer presets from GCS

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -363,6 +363,24 @@ def _discover_local_svgs() -> list[str]:
     return []
 
 
+def _discover_local_presets() -> tuple[list[str], str | None]:
+    search_dirs: list[tuple[Path, str]] = [
+        (Path("backend/web/designer/presets"), "/designer/presets"),
+        (Path("web/presets"), "/presets"),
+        (Path("web/designer/presets"), "/web/designer/presets"),
+    ]
+
+    for directory, base_url in search_dirs:
+        if not directory.exists():
+            continue
+
+        presets = sorted([p.stem for p in directory.glob("*.json")])
+        if presets:
+            return presets, base_url
+
+    return [], None
+
+
 @app.get("/api/list-svgs")
 def list_svgs():
     """List all SVG files available to the designer"""
@@ -390,6 +408,46 @@ def list_svgs():
             logger.info(f"Using {len(svgs)} local SVGs")
 
     return {"svgs": svgs, "base_url": base_url}
+
+
+@app.get("/api/list-presets")
+def list_presets():
+    """List layout presets from GCS or local bundles"""
+    presets: list[str] = []
+    base_url: str | None = None
+
+    if storage_enabled:
+        try:
+            blobs = gcs_bucket.list_blobs(prefix="presets/")
+            for blob in blobs:
+                name = blob.name
+                if not name.endswith(".json"):
+                    continue
+
+                relative = name[len("presets/"):]
+                if not relative or relative.endswith("/"):
+                    continue
+
+                if "/" in relative:
+                    relative = relative.split("/")[-1]
+
+                presets.append(Path(relative).stem)
+
+            if presets:
+                presets = sorted(set(presets))
+                base_url = "/gcs/presets"
+                logger.info(f"Found {len(presets)} presets in bucket")
+        except Exception as e:
+            logger.error(f"Failed to list presets from GCS: {e}")
+
+    if not presets:
+        local_presets, local_base = _discover_local_presets()
+        presets = local_presets
+        base_url = local_base
+        if presets:
+            logger.info(f"Using {len(presets)} local presets")
+
+    return {"presets": presets, "base_url": base_url}
 
 
 def _discover_local_weather_themes() -> list[str]:

--- a/backend/web/designer/overlay_designer_v3_full.html
+++ b/backend/web/designer/overlay_designer_v3_full.html
@@ -949,6 +949,7 @@ let availableInfoTypes = [];
 let renderData = null;
 let svgLibraryBase = '/gcs/assets/svgs';
 let weatherIconBase = '/gcs/assets/weather-icons';
+let presetBaseUrl = '';
 const FALLBACK_WEATHER_ICON = '/designer/svgs/weather_card_blue.svg';
 
 // --- Setup Modal Logic ---
@@ -1589,24 +1590,42 @@ function redo() {
 
 // --- Presets, SVGs, Themes (API) ---
 async function loadPresets() {
+  try {
+    const response = await fetch('/api/list-presets');
+    if (!response.ok) throw new Error(`HTTP ${response.status}`);
+
+    const data = await response.json();
+    availablePresets = data.presets || [];
+    presetBaseUrl = data.base_url || '';
+
+    if (availablePresets.length > 0) {
+      console.log(`Loaded ${availablePresets.length} presets from API`);
+      renderPresetOptions();
+      return;
+    }
+  } catch (error) {
+    console.warn('Preset API unavailable, falling back to static scan:', error.message);
+  }
+
   const paths = ['/presets/', '/web/presets/', '/designer/presets/'];
-  
+
   for (const path of paths) {
     try {
       const response = await fetch(path);
       if (!response.ok) continue;
-      
+
       const html = await response.text();
       const parser = new DOMParser();
       const doc = parser.parseFromString(html, 'text/html');
       const links = doc.querySelectorAll('a');
-      
+
       availablePresets = Array.from(links)
         .map(link => link.getAttribute('href'))
         .filter(href => href && href.endsWith('.json'))
         .map(href => href.split('/').pop().replace('.json', ''));
-      
+
       if (availablePresets.length > 0) {
+        presetBaseUrl = path.replace(/\/$/, '');
         console.log(`Found ${availablePresets.length} presets at ${path}`);
         renderPresetOptions();
         return; // Success
@@ -1615,9 +1634,10 @@ async function loadPresets() {
       console.warn(`Failed to load from ${path}:`, error.message);
     }
   }
-  
+
   console.warn('No presets found in any path');
   availablePresets = [];
+  presetBaseUrl = '';
   renderPresetOptions();
   setStatus('No presets available locally', 2000, true);
 }
@@ -1642,9 +1662,19 @@ function renderPresetOptions() {
 
 async function applyTemplate(key) {
   if (!key) return;
-  
-  const paths = [`/presets/${key}.json`, `/web/presets/${key}.json`, `/designer/presets/${key}.json`];
-  
+
+  const fallbackPaths = [`/presets/${key}.json`, `/web/presets/${key}.json`, `/designer/presets/${key}.json`];
+  const paths = [];
+
+  if (presetBaseUrl) {
+    const base = presetBaseUrl.replace(/\/$/, '');
+    paths.push(`${base}/${key}.json`);
+  }
+
+  fallbackPaths.forEach(path => {
+    if (!paths.includes(path)) paths.push(path);
+  });
+
   for (const path of paths) {
     try {
       const response = await fetch(path);


### PR DESCRIPTION
## Summary
- add a FastAPI endpoint that lists available presets from GCS with a local fallback
- update the designer UI to load presets via the new API and remember the resolved base URL
- keep static directory scanning as a fallback when the API is unavailable

## Testing
- python -m compileall backend

------
https://chatgpt.com/codex/tasks/task_e_690891cafe2c832c85746a656b133098