### PR TITLE
Add Pexels background selection and refresh workflow

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -44,6 +44,22 @@ RENDER_WIDTH = int(os.getenv("RENDER_WIDTH", "800"))
 RENDER_HEIGHT = int(os.getenv("RENDER_HEIGHT", "480"))
 RENDER_PATH = os.getenv("RENDER_PATH", "backend/web/layouts/base.html")
 
+_DEFAULT_PEXELS_CATEGORIES = [
+    "abstract",
+    "geometric",
+    "kids-shapes",
+    "minimal",
+    "paper-collage",
+]
+PEXELS_CATEGORIES = [
+    c.strip()
+    for c in os.getenv("PEXELS_CATEGORIES", ",".join(_DEFAULT_PEXELS_CATEGORIES)).split(",")
+    if c.strip()
+]
+PEXELS_PER_CATEGORY = int(os.getenv("PEXELS_PER_CATEGORY", "8"))
+PEXELS_ORIENTATION = os.getenv("PEXELS_ORIENTATION", "landscape")
+PEXELS_IMAGE_SIZE = os.getenv("PEXELS_IMAGE_SIZE", "large")
+
 storage_enabled = False
 gcs_bucket = None
 playwright_browser = None
@@ -102,6 +118,201 @@ def make_public_url(path: str) -> str:
         return path
     base = PUBLIC_BASE_URL.rstrip("/") if PUBLIC_BASE_URL else f"http://localhost:{PORT}"
     return f"{base}/{path.lstrip('/')}"
+
+
+def get_pexels_categories() -> list[str]:
+    """Return list of configured or discovered Pexels categories"""
+    categories = set(PEXELS_CATEGORIES)
+
+    if storage_enabled and ENABLE_PEXELS:
+        try:
+            blobs = gcs_bucket.list_blobs(prefix="pexels/current/", delimiter="/")
+            prefixes: list[str] = []
+            for page in blobs.pages:
+                prefixes.extend(page.prefixes)
+            for prefix in prefixes:
+                name = prefix.rstrip("/").split("/")[-1]
+                if name:
+                    categories.add(name)
+        except Exception as exc:
+            logger.warning(f"Failed to list Pexels categories: {exc}")
+
+    if not categories:
+        categories = set(_DEFAULT_PEXELS_CATEGORIES)
+
+    return sorted(categories)
+
+
+def _list_pexels_objects(category: str) -> list[str]:
+    """List blob names for a category under pexels/current"""
+    if not storage_enabled or not ENABLE_PEXELS:
+        return []
+
+    safe_category = category.strip("/")
+    prefix = f"pexels/current/{safe_category}/"
+    names: list[str] = []
+
+    try:
+        blobs = gcs_bucket.list_blobs(prefix=prefix)
+        for blob in blobs:
+            if blob.name.endswith("/"):
+                continue
+            if blob.size == 0:
+                continue
+            names.append(blob.name)
+    except Exception as exc:
+        logger.warning(f"Failed to list Pexels objects for {category}: {exc}")
+
+    return names
+
+
+def choose_pexels_background(category: str | None) -> dict | None:
+    """Select a random background image for the requested category"""
+    if not ENABLE_PEXELS or not storage_enabled:
+        return None
+
+    categories = get_pexels_categories()
+    if not categories:
+        return None
+
+    selected_category = category or ""
+    if selected_category not in categories:
+        selected_category = categories[0]
+
+    blob_names = _list_pexels_objects(selected_category)
+
+    if not blob_names:
+        # Fallback to the first category that has files
+        for fallback in categories:
+            blob_names = _list_pexels_objects(fallback)
+            if blob_names:
+                selected_category = fallback
+                break
+
+    if not blob_names:
+        return None
+
+    blob_name = random.choice(blob_names)
+    image_name = Path(blob_name).name
+    public_path = f"gcs/{blob_name}"
+
+    return {
+        "category": selected_category,
+        "image": image_name,
+        "path": public_path,
+        "url": make_public_url(public_path),
+        "categories": categories,
+    }
+
+
+def rollover_pexels_current(categories: list[str], date_stamp: str) -> dict[str, int]:
+    """Move current images to cache/date/category"""
+    moved: dict[str, int] = {category: 0 for category in categories}
+
+    if not storage_enabled or not ENABLE_PEXELS:
+        return moved
+
+    for category in categories:
+        prefix = f"pexels/current/{category.strip('/')}/"
+        cache_prefix = f"pexels/cache/{date_stamp}/{category.strip('/')}/"
+
+        try:
+            blobs = gcs_bucket.list_blobs(prefix=prefix)
+            for blob in blobs:
+                if blob.name.endswith("/") or blob.size == 0:
+                    continue
+                destination = cache_prefix + Path(blob.name).name
+                gcs_bucket.copy_blob(blob, gcs_bucket, destination)
+                blob.delete()
+                moved[category] += 1
+        except Exception as exc:
+            logger.warning(f"Failed to rollover Pexels images for {category}: {exc}")
+
+    return moved
+
+
+async def fetch_pexels_category(
+    client: httpx.AsyncClient,
+    category: str,
+    api_key: str,
+) -> tuple[int, list[str]]:
+    """Fetch new images for a category and upload to GCS"""
+    headers = {"Authorization": api_key}
+    params = {
+        "query": category.replace("-", " "),
+        "per_page": max(1, PEXELS_PER_CATEGORY),
+        "orientation": PEXELS_ORIENTATION,
+        "size": PEXELS_IMAGE_SIZE,
+    }
+
+    saved_files: list[str] = []
+
+    try:
+        response = await client.get(
+            "https://api.pexels.com/v1/search",
+            headers=headers,
+            params=params,
+            timeout=20,
+        )
+        response.raise_for_status()
+    except Exception as exc:
+        logger.error(f"Pexels search failed for {category}: {exc}")
+        return 0, saved_files
+
+    data = response.json()
+    photos = data.get("photos", [])
+    if not photos:
+        logger.warning(f"No Pexels photos returned for {category}")
+        return 0, saved_files
+
+    random.shuffle(photos)
+    selected = photos[: PEXELS_PER_CATEGORY]
+
+    for index, photo in enumerate(selected):
+        src = photo.get("src", {})
+        image_url = src.get("landscape") or src.get("large") or src.get("large2x")
+        if not image_url:
+            continue
+
+        filename = f"{category}_{photo.get('id', index)}.jpg"
+        object_name = f"pexels/current/{category}/{filename}"
+
+        try:
+            image_response = await client.get(image_url, timeout=30)
+            image_response.raise_for_status()
+            gcs_write_bytes(object_name, image_response.content, "image/jpeg")
+            saved_files.append(object_name)
+        except Exception as exc:
+            logger.warning(f"Failed to download Pexels image {image_url}: {exc}")
+
+    return len(saved_files), saved_files
+
+
+async def refresh_pexels_assets(categories: list[str]) -> dict[str, dict[str, int | list[str]]]:
+    """Rollover current images and fetch new ones for each category"""
+    summary: dict[str, dict[str, int | list[str]]] = {}
+
+    if not storage_enabled or not ENABLE_PEXELS:
+        return summary
+
+    api_key = os.getenv("PEXELS_API_KEY")
+    if not api_key:
+        raise RuntimeError("PEXELS_API_KEY not configured")
+
+    today = datetime.utcnow().strftime("%Y-%m-%d")
+    rollover_counts = rollover_pexels_current(categories, today)
+
+    async with httpx.AsyncClient() as client:
+        for category in categories:
+            downloaded, files = await fetch_pexels_category(client, category, api_key)
+            summary[category] = {
+                "rolled": rollover_counts.get(category, 0),
+                "downloaded": downloaded,
+                "files": files,
+            }
+
+    return summary
+
 
 def gcs_read_json(key: str) -> dict:
     """Read JSON from GCS"""
@@ -200,8 +411,27 @@ async def build_render_data(device: str = "familydisplay") -> dict:
     weather["city"] = city
     
     dad_joke = await get_joke()
-    
-    bg_url = make_public_url("gcs/pexels/current/abstract_0.jpg")
+
+    layout_meta = layout.get("meta", {}) if isinstance(layout, dict) else {}
+    selected_category = layout_meta.get("pexelsCategory")
+    pexels_info = None
+
+    if ENABLE_PEXELS and storage_enabled:
+        pexels_info = choose_pexels_background(selected_category)
+
+    if pexels_info:
+        bg_url = pexels_info["url"]
+    else:
+        bg_url = make_public_url("gcs/pexels/current/abstract_0.jpg")
+        if ENABLE_PEXELS:
+            categories = get_pexels_categories()
+            pexels_info = {
+                "category": selected_category or (categories[0] if categories else None),
+                "image": None,
+                "path": None,
+                "url": bg_url,
+                "categories": categories,
+            }
     
     now = datetime.now()
     date_str = now.strftime("%a, %d %b")
@@ -217,6 +447,7 @@ async def build_render_data(device: str = "familydisplay") -> dict:
         "dad_joke": dad_joke,
         "date": date_str,
         "bg_url": bg_url,
+        "pexels": pexels_info,
         "svg_base": svg_base,
         "timestamp": now.isoformat()
     }
@@ -490,6 +721,59 @@ def list_weather_themes():
         icon_base = "/gcs/assets/weather-icons" if storage_enabled else "/designer/weather-icons"
 
     return {"themes": themes, "icon_base": icon_base}
+
+
+@app.get("/api/pexels/categories")
+def list_pexels_categories():
+    """Expose available Pexels categories to the designer"""
+    categories = get_pexels_categories()
+    return {
+        "categories": categories,
+        "enabled": ENABLE_PEXELS and storage_enabled,
+    }
+
+
+async def _run_pexels_prefetch(token: str | None):
+    if token != ADMIN_TOKEN:
+        raise HTTPException(status_code=403, detail="Invalid token")
+
+    if not ENABLE_PEXELS:
+        raise HTTPException(status_code=503, detail="Pexels disabled")
+
+    if not storage_enabled:
+        raise HTTPException(status_code=503, detail="GCS not configured")
+
+    categories = get_pexels_categories()
+    if not categories:
+        raise HTTPException(status_code=404, detail="No Pexels categories configured")
+
+    try:
+        summary = await refresh_pexels_assets(categories)
+    except RuntimeError as exc:
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+    except Exception as exc:
+        logger.error(f"Pexels prefetch failed: {exc}")
+        raise HTTPException(status_code=500, detail="Pexels prefetch failed") from exc
+
+    return {
+        "status": "ok",
+        "categories": categories,
+        "summary": summary,
+        "timestamp": datetime.utcnow().isoformat() + "Z",
+    }
+
+
+@app.post("/admin/prefetch")
+async def admin_prefetch_post(token: str = None):
+    """Trigger rollover + fetch of Pexels assets"""
+    return await _run_pexels_prefetch(token)
+
+
+@app.get("/admin/prefetch")
+async def admin_prefetch_get(token: str = None):
+    """GET-compatible trigger for schedulers"""
+    return await _run_pexels_prefetch(token)
+
 
 @app.get("/layouts/{device}")
 def get_layout(device: str, x_admin_token: str = Header(None)):

--- a/backend/web/designer/overlay_designer_v3_full.html
+++ b/backend/web/designer/overlay_designer_v3_full.html
@@ -650,6 +650,11 @@ button:disabled:hover {
               <div class="quick-add-btn-label">Weather</div>
             </button>
           </div>
+          <label style="display:block;margin-top:12px;">
+            <span style="display:block;font-size:11px;color:var(--muted);letter-spacing:0.08em;text-transform:uppercase;">Background Category</span>
+            <select id="pexelsCategorySelect" style="width:100%;margin-top:6px"></select>
+          </label>
+          <div class="help-text" style="margin-top:4px">Random images from this Pexels category will be used for the display background.</div>
         </div>
       </div>
 
@@ -951,6 +956,10 @@ let svgLibraryBase = '/gcs/assets/svgs';
 let weatherIconBase = '/gcs/assets/weather-icons';
 let presetBaseUrl = '';
 const FALLBACK_WEATHER_ICON = '/designer/svgs/weather_card_blue.svg';
+const DEFAULT_PEXELS_CATEGORIES = ['abstract', 'geometric', 'kids-shapes', 'minimal', 'paper-collage'];
+const pexelsCategorySelect = document.getElementById('pexelsCategorySelect');
+let availablePexelsCategories = [...DEFAULT_PEXELS_CATEGORIES];
+let currentPexelsCategory = availablePexelsCategories[0] || '';
 
 // --- Setup Modal Logic ---
 function showSetupModal() {
@@ -1023,6 +1032,28 @@ document.getElementById('setupTogglePasskey').addEventListener('click', () => {
 });
 document.getElementById('editSettingsBtn').addEventListener('click', showSetupModal);
 
+if (pexelsCategorySelect) {
+  pexelsCategorySelect.addEventListener('change', (event) => {
+    const value = (event.target.value || '').trim();
+    const previous = currentPexelsCategory;
+    currentPexelsCategory = value;
+
+    if (value && !availablePexelsCategories.includes(value)) {
+      availablePexelsCategories.push(value);
+    }
+
+    if (previous !== value) {
+      saveAction(`Background category → ${formatPexelsLabel(value)}`);
+    }
+
+    if (value) {
+      setStatus(`Background category: ${formatPexelsLabel(value)}`, 1500);
+    } else {
+      setStatus('Background category cleared', 1500);
+    }
+  });
+}
+
 function checkSetupNeeded() {
   if (FORCE_SETUP_ON_LOAD) {
     setTimeout(showSetupModal, 400);
@@ -1051,6 +1082,79 @@ function setStatus(msg, timeout = 0, isError = false) {
       statusText.classList.remove('error');
     }, timeout);
   }
+}
+
+function formatPexelsLabel(category) {
+  if (!category) return 'Default';
+  return category
+    .split('-')
+    .map(word => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ');
+}
+
+function renderPexelsCategoryOptions() {
+  if (!pexelsCategorySelect) return;
+
+  const unique = Array.from(new Set(availablePexelsCategories.filter(Boolean)));
+  availablePexelsCategories = unique.length ? unique : [...DEFAULT_PEXELS_CATEGORIES];
+
+  const previous = currentPexelsCategory || pexelsCategorySelect.value;
+
+  pexelsCategorySelect.innerHTML = '';
+
+  if (!availablePexelsCategories.length) {
+    const option = document.createElement('option');
+    option.value = '';
+    option.textContent = 'No categories available';
+    pexelsCategorySelect.appendChild(option);
+    pexelsCategorySelect.disabled = true;
+    currentPexelsCategory = '';
+    return;
+  }
+
+  pexelsCategorySelect.disabled = false;
+
+  availablePexelsCategories.forEach(category => {
+    const option = document.createElement('option');
+    option.value = category;
+    option.textContent = formatPexelsLabel(category);
+    pexelsCategorySelect.appendChild(option);
+  });
+
+  if (previous && availablePexelsCategories.includes(previous)) {
+    currentPexelsCategory = previous;
+  } else {
+    currentPexelsCategory = availablePexelsCategories[0];
+  }
+
+  pexelsCategorySelect.value = currentPexelsCategory || '';
+}
+
+async function loadPexelsCategories() {
+  if (!pexelsCategorySelect) return;
+
+  try {
+    const response = await fetch('/api/pexels/categories');
+    if (!response.ok) throw new Error(`HTTP ${response.status}`);
+
+    const data = await response.json();
+    const categories = (data.categories || []).filter(Boolean);
+
+    if (categories.length) {
+      availablePexelsCategories = categories;
+    }
+
+    if (currentPexelsCategory && !availablePexelsCategories.includes(currentPexelsCategory)) {
+      availablePexelsCategories.unshift(currentPexelsCategory);
+    }
+  } catch (error) {
+    console.warn('Failed to load Pexels categories:', error.message);
+    if (currentPexelsCategory && !availablePexelsCategories.includes(currentPexelsCategory)) {
+      availablePexelsCategories.unshift(currentPexelsCategory);
+    }
+  }
+
+  renderPexelsCategoryOptions();
 }
 
 function rgbToHex(rgb) {
@@ -1112,6 +1216,15 @@ async function fetchRenderData() {
     renderData = await response.json();
     if (renderData.svg_base) {
       svgLibraryBase = renderData.svg_base;
+    }
+
+    const metaCategory = renderData?.layout?.meta?.pexelsCategory;
+    if (metaCategory) {
+      currentPexelsCategory = metaCategory;
+      if (!availablePexelsCategories.includes(metaCategory)) {
+        availablePexelsCategories.push(metaCategory);
+      }
+      renderPexelsCategoryOptions();
     }
 
     availableInfoTypes = ['CUSTOM'];
@@ -1785,6 +1898,7 @@ async function loadSVGLibrary() {
 
 // --- Import/Export & Save/Load ---
 function exportToJSON() {
+  const selectedCategory = (currentPexelsCategory || pexelsCategorySelect?.value || '').trim();
   const elements = Array.from(canvas.querySelectorAll('.el')).map(el => {
     const domKind = el.classList.contains('text') ? 'text' :
             el.classList.contains('icon') ? 'icon' :
@@ -1865,7 +1979,8 @@ function exportToJSON() {
     meta: {
       width: 800,
       height: 480,
-      iconTheme: 'happy-skies' // This should be editable
+      iconTheme: 'happy-skies', // This should be editable
+      pexelsCategory: selectedCategory || null
     },
     elements: elements
   };
@@ -1878,7 +1993,18 @@ async function loadFromJSON(data) {
   if (data.meta && data.meta.name) {
     currentPresetName = data.meta.name;
   }
-  
+
+  const metaCategory = data.meta?.pexelsCategory || '';
+  if (metaCategory) {
+    currentPexelsCategory = metaCategory;
+    if (!availablePexelsCategories.includes(metaCategory)) {
+      availablePexelsCategories.push(metaCategory);
+    }
+  } else if (!currentPexelsCategory) {
+    currentPexelsCategory = availablePexelsCategories[0] || '';
+  }
+  renderPexelsCategoryOptions();
+
   const elementPromises = (data.elements || []).map(async (elem) => {
     const elementKind = elem.kind === 'svg-overlay' ? 'svg' : elem.kind;
     const options = { ...elem };
@@ -2709,7 +2835,8 @@ async function init() {
   setupPanelToggles();
   checkSetupNeeded();
   autoCollapsePanels(); // Collapse all on start
-  
+  renderPexelsCategoryOptions();
+
   // Disable API-dependent buttons by default
   document.getElementById('applyTemplateBtn').disabled = true;
   document.getElementById('quickAddFancyBox').disabled = true;
@@ -2722,9 +2849,10 @@ async function init() {
       loadPresets(),
       loadSVGLibrary(),
       loadWeatherThemes(),
+      loadPexelsCategories(),
       fetchRenderData()
     ]);
-    
+
     console.log('Initialization complete.');
     setStatus('Ready', 0);
     

--- a/backend/web/layouts/base.html
+++ b/backend/web/layouts/base.html
@@ -228,9 +228,10 @@
         return;
       }
 
-      // Set background
-      if (data.bg_url) {
-        bg.src = data.bg_url;
+      // Set background (prefer dynamic Pexels selection)
+      const backgroundUrl = (data.pexels && data.pexels.url) || data.bg_url;
+      if (backgroundUrl) {
+        bg.src = backgroundUrl;
       }
 
       const layout = data.layout;


### PR DESCRIPTION
## Summary
- expose configurable Pexels categories, random background selection, and admin prefetch rollover in the backend
- surface the chosen Pexels category throughout render data and base.html so displays use the random image
- add a category dropdown to the designer that saves to layout metadata and fetches categories from the API

## Testing
- python -m compileall backend

------
https://chatgpt.com/codex/tasks/task_e_690897f552e8832cad85e8865b7d8733