### PR TITLE
Fix weather data rendering and designer layering

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -2,7 +2,7 @@ import os
 import json
 import random
 import logging
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Dict, Any
 from urllib.parse import quote
@@ -381,18 +381,93 @@ async def get_weather(city: str) -> dict:
                     r = await client.get(url, timeout=5)
                     if r.status_code == 200:
                         data = r.json()
-                        return {
-                            "temp": round(data["main"]["temp"]),
-                            "feels_like": round(data["main"]["feels_like"]),
-                            "humidity": data["main"]["humidity"],
+                        weather: dict[str, Any] = {
+                            "temp": round(data["main"].get("temp", 0)),
+                            "feels_like": round(data["main"].get("feels_like", 0)),
+                            "humidity": data.get("main", {}).get("humidity"),
                             "rain": data.get("rain", {}).get("1h", 0),
-                            "wind": round(data["wind"]["speed"]),
-                            "icon": data["weather"][0]["icon"],
-                            "desc": data["weather"][0]["description"].title()
+                            "wind": round(data.get("wind", {}).get("speed", 0)),
+                            "icon": data.get("weather", [{}])[0].get("icon", "01d"),
+                            "desc": data.get("weather", [{}])[0].get("description", "").title() or "Sunny",
                         }
+
+                        tz_offset = data.get("timezone", 0)
+                        weather["timezone_offset"] = tz_offset
+
+                        coord = data.get("coord", {})
+                        lat = coord.get("lat")
+                        lon = coord.get("lon")
+
+                        if lat is not None and lon is not None:
+                            try:
+                                forecast_url = (
+                                    "https://api.openweathermap.org/data/2.5/forecast"
+                                    f"?lat={lat}&lon={lon}&appid={api_key}&units=metric"
+                                )
+                                forecast_resp = await client.get(forecast_url, timeout=5)
+                                forecast_resp.raise_for_status()
+                                forecast_data = forecast_resp.json()
+
+                                target_date = (
+                                    datetime.now(timezone.utc)
+                                    .astimezone(timezone(timedelta(seconds=tz_offset)))
+                                    .date()
+                                )
+
+                                min_samples: list[float] = []
+                                max_samples: list[float] = []
+
+                                local_timezone = timezone(timedelta(seconds=tz_offset))
+
+                                for entry in forecast_data.get("list", []):
+                                    dt_val = entry.get("dt")
+                                    if dt_val is None:
+                                        continue
+
+                                    local_dt = datetime.fromtimestamp(dt_val, tz=timezone.utc).astimezone(local_timezone)
+                                    if local_dt.date() != target_date:
+                                        continue
+
+                                    main_block = entry.get("main", {})
+                                    min_val = main_block.get("temp_min")
+                                    max_val = main_block.get("temp_max")
+
+                                    if isinstance(min_val, (int, float)):
+                                        min_samples.append(float(min_val))
+                                    if isinstance(max_val, (int, float)):
+                                        max_samples.append(float(max_val))
+
+                                if min_samples:
+                                    weather["temp_min"] = round(sum(min_samples) / len(min_samples))
+                                else:
+                                    api_min = data.get("main", {}).get("temp_min")
+                                    if isinstance(api_min, (int, float)):
+                                        weather["temp_min"] = round(api_min)
+
+                                if max_samples:
+                                    weather["temp_max"] = round(sum(max_samples) / len(max_samples))
+                                else:
+                                    api_max = data.get("main", {}).get("temp_max")
+                                    if isinstance(api_max, (int, float)):
+                                        weather["temp_max"] = round(api_max)
+                            except Exception as exc:
+                                logger.warning(f"OpenWeather forecast failed: {exc}")
+                                api_min = data.get("main", {}).get("temp_min")
+                                api_max = data.get("main", {}).get("temp_max")
+                                if isinstance(api_min, (int, float)):
+                                    weather["temp_min"] = round(api_min)
+                                if isinstance(api_max, (int, float)):
+                                    weather["temp_max"] = round(api_max)
+
+                        if "temp_min" not in weather:
+                            weather["temp_min"] = weather["temp"]
+                        if "temp_max" not in weather:
+                            weather["temp_max"] = weather["temp"]
+
+                        return weather
             except Exception as e:
                 logger.warning(f"OpenWeather failed: {e}")
-    
+
     return {
         "temp": 33,
         "feels_like": 33,
@@ -400,7 +475,10 @@ async def get_weather(city: str) -> dict:
         "rain": 0,
         "wind": 5,
         "icon": "01d",
-        "desc": "Sunny"
+        "desc": "Sunny",
+        "temp_min": 30,
+        "temp_max": 36,
+        "timezone_offset": 0,
     }
 
 async def get_joke() -> str:
@@ -449,7 +527,16 @@ async def build_render_data(device: str = "familydisplay") -> dict:
     weather["icon_theme"] = icon_theme
     weather["icon_url"] = resolve_weather_icon_url(icon_theme, icon_code)
     weather["city"] = city
-    
+
+    tz_offset = weather.get("timezone_offset")
+    now_utc = datetime.now(timezone.utc)
+    if isinstance(tz_offset, (int, float)):
+        city_tz = timezone(timedelta(seconds=int(tz_offset)), name=city)
+        now = now_utc.astimezone(city_tz)
+    else:
+        now = now_utc
+    weather["local_datetime"] = now.isoformat()
+
     dad_joke = await get_joke()
 
     layout_meta = layout.get("meta", {}) if isinstance(layout, dict) else {}
@@ -473,7 +560,6 @@ async def build_render_data(device: str = "familydisplay") -> dict:
                 "categories": categories,
             }
     
-    now = datetime.now()
     date_str = now.strftime("%a, %d %b")
     
     if storage_enabled:

--- a/backend/web/designer/overlay_designer_v3_full.html
+++ b/backend/web/designer/overlay_designer_v3_full.html
@@ -1181,6 +1181,9 @@ function getDynamicTextForType(type) {
 
   switch (type) {
     case 'TEMP':
+      if (weather.temp_min != null && weather.temp_max != null) {
+        return `${weather.temp_min}° / ${weather.temp_max}°`;
+      }
       return weather.temp != null ? `${weather.temp}°C` : '--°C';
     case 'FEELS_LIKE':
       return weather.feels_like != null ? `${weather.feels_like}°C` : '--°C';
@@ -1543,6 +1546,32 @@ function clearResizeHandles(el) {
   el.querySelectorAll('.resize-handle').forEach(handle => handle.remove());
 }
 
+function computeElementLayer(el) {
+  if (!el) return 10;
+  if (el.classList.contains('text') || el.classList.contains('icon')) {
+    return 30;
+  }
+
+  if (el.classList.contains('svg-overlay')) {
+    const src = (el.dataset.src || el.dataset.svgName || '').toString();
+    if (src === 'weather-icon' || src.startsWith('weather-')) {
+      return 35;
+    }
+    return 20;
+  }
+
+  if (el.classList.contains('box')) {
+    return 15;
+  }
+
+  return 10;
+}
+
+function applyElementLayer(el) {
+  if (!el) return;
+  el.style.zIndex = String(computeElementLayer(el));
+}
+
 function startResize(e, handleType) {
   e.stopPropagation();
   isResizing = true;
@@ -1627,9 +1656,8 @@ function addElement(kind, x, y, w, h, options = {}) {
   el.style.width = w + 'px';
   el.style.height = h + 'px';
   el.style.opacity = options.opacity !== undefined ? options.opacity : 1;
-  el.style.zIndex = '10'; // All elements on same z-index, selection outline handles visibility
   el.dataset.rotation = options.rotation || 0;
-  
+
   if (actualKind === 'text' || actualKind === 'icon') {
     const content = document.createElement('div');
     content.className = 'el-content';
@@ -1666,7 +1694,18 @@ function addElement(kind, x, y, w, h, options = {}) {
     el.dataset.gradEnd = options.gradEnd || '#1a6ec0';
     el.dataset.gradAngle = options.gradAngle || 135;
     el.dataset.svgName = options.svgName || 'svg';
-    
+
+    let srcValue = options.src;
+    if (!srcValue && options.svgName && options.svgName.startsWith('weather-')) {
+      srcValue = 'weather-icon';
+    }
+    if (srcValue && srcValue.startsWith('weather-')) {
+      srcValue = 'weather-icon';
+    }
+    if (srcValue) {
+      el.dataset.src = srcValue;
+    }
+
     const svg = el.querySelector('svg');
     if (svg) {
       svg.style.width = '100%';
@@ -1678,7 +1717,8 @@ function addElement(kind, x, y, w, h, options = {}) {
     updateSVGContent(el);
     console.log('Created SVG element:', options.svgName);
   }
-  
+
+  applyElementLayer(el);
   canvas.appendChild(el);
   console.log('Element appended to canvas. Total elements:', canvas.querySelectorAll('.el').length);
   selectEl(el);
@@ -2073,7 +2113,8 @@ function exportToJSON() {
       const svgName = el.dataset.svgName || 'svg';
       base.kind = 'svg';
       base.svgName = svgName;
-      base.src = svgName;
+      const storedSrc = el.dataset.src || svgName;
+      base.src = storedSrc;
       base.fillType = el.dataset.fillType || 'none';
       if (base.fillType === 'solid') {
         base.fillColor = el.dataset.fillColor;
@@ -2414,7 +2455,8 @@ document.getElementById('quickAddIcon').addEventListener('click', async () => {
         addElement('svg', 100, 100, 120, 120, {
           svgContent,
           svgName: `weather-${theme}`,
-          fillType: 'none'
+          fillType: 'none',
+          src: 'weather-icon'
         });
 
         modal.classList.add('hidden');
@@ -2481,7 +2523,8 @@ document.getElementById('duplicateBtn').addEventListener('click', () => {
   // Remove selection state from clone
   clone.classList.remove('selected');
   clone.querySelectorAll('.resize-handle').forEach(h => h.remove());
-  
+
+  applyElementLayer(clone);
   canvas.appendChild(clone);
   selectEl(clone); // Select the new clone
   saveAction('Duplicate');

--- a/backend/web/layouts/base.html
+++ b/backend/web/layouts/base.html
@@ -154,7 +154,10 @@
           return data.weather?.city || "City";
         
         case "TEMP":
-          return data.weather?.temp != null 
+          if (data.weather?.temp_min != null && data.weather?.temp_max != null) {
+            return `${data.weather.temp_min}° / ${data.weather.temp_max}°`;
+          }
+          return data.weather?.temp != null
             ? data.weather.temp + "°C"
             : "--°C";
         
@@ -177,7 +180,28 @@
 
         default:
           return el.text || "";
+    }
+    }
+
+    function getLayerZIndex(el, providedKind) {
+      const kind = (providedKind || el.kind || "").toLowerCase();
+      if (kind === "text" || kind === "icon") {
+        return 30;
       }
+
+      if (kind === "svg" || kind === "svg-overlay" || kind === "image") {
+        const source = String(el.src || el.svgName || "");
+        if (source === "weather-icon" || source.startsWith("weather-")) {
+          return 35;
+        }
+        return 20;
+      }
+
+      if (kind === "box") {
+        return 15;
+      }
+
+      return 10;
     }
 
     /**
@@ -268,6 +292,7 @@
         if (el.opacity != null) div.style.opacity = el.opacity;
 
         const kind = (el.kind || "").toLowerCase();
+        div.style.zIndex = getLayerZIndex(el, kind);
 
         // ============================================================
         // TEXT ELEMENTS


### PR DESCRIPTION
## Summary
- fetch OpenWeather forecasts to provide local min/max temperatures and timezone-aware timestamps
- ensure layout renderer and designer use min/max strings for temperature and keep weather icons layered above overlays
- store weather icon bindings in exported layouts so base.html resolves the dynamic icon URL correctly

## Testing
- python -m compileall backend

------
https://chatgpt.com/codex/tasks/task_e_690937d935a4832ca0ab09e83e42854e