### PR TITLE
Cache OpenWeather icons and streamline designer weather icon flow

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -2,7 +2,7 @@ import os
 import json
 import random
 import logging
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Dict, Any
 from urllib.parse import quote
@@ -39,7 +39,9 @@ ENABLE_JOKES_API = os.getenv("ENABLE_JOKES_API", "true").lower() == "true"
 ENABLE_EMAIL_USERS = os.getenv("ENABLE_EMAIL_USERS", "false").lower() == "true"
 CITY_MODE = os.getenv("CITY_MODE", "default")
 DEFAULT_CITY = os.getenv("DEFAULT_CITY", "Darwin")
-DEFAULT_ICON_THEME = os.getenv("WEATHER_ICON_PACK", "happy-skies")
+OPENWEATHER_ICON_BASE = "https://openweathermap.org/img/wn"
+OPENWEATHER_ICON_SCALE = os.getenv("OPENWEATHER_ICON_SCALE", "@4x")
+FALLBACK_WEATHER_ICON = "designer/svgs/weather_card_blue.svg"
 RENDER_WIDTH = int(os.getenv("RENDER_WIDTH", "800"))
 RENDER_HEIGHT = int(os.getenv("RENDER_HEIGHT", "480"))
 RENDER_PATH = os.getenv("RENDER_PATH", "backend/web/layouts/base.html")
@@ -205,10 +207,55 @@ def choose_pexels_background(category: str | None) -> dict | None:
     }
 
 
-def resolve_weather_icon_url(icon_theme: str, icon_code: str | None) -> str:
-    """Return a weather icon URL, falling back to day variants when needed."""
+def _openweather_icon_filename(icon_code: str) -> str:
+    scale = OPENWEATHER_ICON_SCALE or "@4x"
+    if not scale.startswith("@"):
+        scale = f"@{scale}"
+    return f"{icon_code}{scale}.png"
 
-    safe_theme = icon_theme or DEFAULT_ICON_THEME
+
+async def _fetch_and_cache_openweather_icon(
+    client: httpx.AsyncClient, icon_code: str
+) -> str | None:
+    """Ensure an OpenWeather icon is cached and return its public URL."""
+
+    filename = _openweather_icon_filename(icon_code)
+    blob_path = f"icons/openweather/{filename}"
+    public_path = f"gcs/{blob_path}"
+
+    if storage_enabled:
+        try:
+            blob = gcs_bucket.blob(blob_path)
+            if blob.exists():
+                return make_public_url(public_path)
+        except Exception as exc:
+            logger.warning(f"Failed to inspect cached icon {blob_path}: {exc}")
+
+    if not storage_enabled:
+        return f"{OPENWEATHER_ICON_BASE}/{filename}"
+
+    icon_url = f"{OPENWEATHER_ICON_BASE}/{filename}"
+
+    try:
+        response = await client.get(icon_url, timeout=10)
+        response.raise_for_status()
+    except Exception as exc:
+        logger.warning(f"OpenWeather icon fetch failed for {icon_code}: {exc}")
+        return None
+
+    try:
+        gcs_write_bytes(blob_path, response.content, "image/png")
+        return make_public_url(public_path)
+    except Exception as exc:
+        logger.warning(f"Failed to cache OpenWeather icon {icon_code}: {exc}")
+        return icon_url
+
+
+async def resolve_openweather_icon(
+    client: httpx.AsyncClient, icon_code: str | None
+) -> str:
+    """Resolve an icon URL, preferring cached copies then day variants."""
+
     candidates: list[str] = []
 
     if icon_code:
@@ -220,28 +267,11 @@ def resolve_weather_icon_url(icon_theme: str, icon_code: str | None) -> str:
         candidates.append("01d")
 
     for code in candidates:
-        if storage_enabled:
-            blob_path = f"assets/weather-icons/{safe_theme}/{code}.svg"
-            try:
-                blob = gcs_bucket.blob(blob_path)
-                if blob.exists():
-                    return make_public_url(f"gcs/{blob_path}")
-            except Exception as exc:
-                logger.warning(f"Failed to check weather icon {blob_path}: {exc}")
-        else:
-            local_roots = [
-                Path("backend/web/designer/weather-icons"),
-                Path("web/designer/weather-icons"),
-            ]
-            for root in local_roots:
-                local_path = root / safe_theme / f"{code}.svg"
-                if local_path.exists():
-                    return make_public_url(f"designer/weather-icons/{safe_theme}/{code}.svg")
+        cached = await _fetch_and_cache_openweather_icon(client, code)
+        if cached:
+            return cached
 
-    fallback_code = candidates[0]
-    if storage_enabled:
-        return make_public_url(f"gcs/assets/weather-icons/{safe_theme}/{fallback_code}.svg")
-    return make_public_url(f"designer/weather-icons/{safe_theme}/{fallback_code}.svg")
+    return make_public_url(FALLBACK_WEATHER_ICON)
 
 
 def rollover_pexels_current(categories: list[str], date_stamp: str) -> dict[str, int]:
@@ -381,18 +411,97 @@ async def get_weather(city: str) -> dict:
                     r = await client.get(url, timeout=5)
                     if r.status_code == 200:
                         data = r.json()
-                        return {
-                            "temp": round(data["main"]["temp"]),
-                            "feels_like": round(data["main"]["feels_like"]),
-                            "humidity": data["main"]["humidity"],
+                        weather: dict[str, Any] = {
+                            "temp": round(data["main"].get("temp", 0)),
+                            "feels_like": round(data["main"].get("feels_like", 0)),
+                            "humidity": data.get("main", {}).get("humidity"),
                             "rain": data.get("rain", {}).get("1h", 0),
-                            "wind": round(data["wind"]["speed"]),
-                            "icon": data["weather"][0]["icon"],
-                            "desc": data["weather"][0]["description"].title()
+                            "wind": round(data.get("wind", {}).get("speed", 0)),
+                            "icon": data.get("weather", [{}])[0].get("icon", "01d"),
+                            "desc": data.get("weather", [{}])[0].get("description", "").title() or "Sunny",
                         }
+
+                        weather["icon_url"] = await resolve_openweather_icon(
+                            client, weather.get("icon")
+                        )
+
+                        tz_offset = data.get("timezone", 0)
+                        weather["timezone_offset"] = tz_offset
+
+                        coord = data.get("coord", {})
+                        lat = coord.get("lat")
+                        lon = coord.get("lon")
+
+                        if lat is not None and lon is not None:
+                            try:
+                                forecast_url = (
+                                    "https://api.openweathermap.org/data/2.5/forecast"
+                                    f"?lat={lat}&lon={lon}&appid={api_key}&units=metric"
+                                )
+                                forecast_resp = await client.get(forecast_url, timeout=5)
+                                forecast_resp.raise_for_status()
+                                forecast_data = forecast_resp.json()
+
+                                target_date = (
+                                    datetime.now(timezone.utc)
+                                    .astimezone(timezone(timedelta(seconds=tz_offset)))
+                                    .date()
+                                )
+
+                                min_samples: list[float] = []
+                                max_samples: list[float] = []
+
+                                local_timezone = timezone(timedelta(seconds=tz_offset))
+
+                                for entry in forecast_data.get("list", []):
+                                    dt_val = entry.get("dt")
+                                    if dt_val is None:
+                                        continue
+
+                                    local_dt = datetime.fromtimestamp(dt_val, tz=timezone.utc).astimezone(local_timezone)
+                                    if local_dt.date() != target_date:
+                                        continue
+
+                                    main_block = entry.get("main", {})
+                                    min_val = main_block.get("temp_min")
+                                    max_val = main_block.get("temp_max")
+
+                                    if isinstance(min_val, (int, float)):
+                                        min_samples.append(float(min_val))
+                                    if isinstance(max_val, (int, float)):
+                                        max_samples.append(float(max_val))
+
+                                if min_samples:
+                                    weather["temp_min"] = round(sum(min_samples) / len(min_samples))
+                                else:
+                                    api_min = data.get("main", {}).get("temp_min")
+                                    if isinstance(api_min, (int, float)):
+                                        weather["temp_min"] = round(api_min)
+
+                                if max_samples:
+                                    weather["temp_max"] = round(sum(max_samples) / len(max_samples))
+                                else:
+                                    api_max = data.get("main", {}).get("temp_max")
+                                    if isinstance(api_max, (int, float)):
+                                        weather["temp_max"] = round(api_max)
+                            except Exception as exc:
+                                logger.warning(f"OpenWeather forecast failed: {exc}")
+                                api_min = data.get("main", {}).get("temp_min")
+                                api_max = data.get("main", {}).get("temp_max")
+                                if isinstance(api_min, (int, float)):
+                                    weather["temp_min"] = round(api_min)
+                                if isinstance(api_max, (int, float)):
+                                    weather["temp_max"] = round(api_max)
+
+                        if "temp_min" not in weather:
+                            weather["temp_min"] = weather["temp"]
+                        if "temp_max" not in weather:
+                            weather["temp_max"] = weather["temp"]
+
+                        return weather
             except Exception as e:
                 logger.warning(f"OpenWeather failed: {e}")
-    
+
     return {
         "temp": 33,
         "feels_like": 33,
@@ -400,7 +509,11 @@ async def get_weather(city: str) -> dict:
         "rain": 0,
         "wind": 5,
         "icon": "01d",
-        "desc": "Sunny"
+        "desc": "Sunny",
+        "temp_min": 30,
+        "temp_max": 36,
+        "timezone_offset": 0,
+        "icon_url": make_public_url(FALLBACK_WEATHER_ICON),
     }
 
 async def get_joke() -> str:
@@ -438,18 +551,24 @@ async def build_render_data(device: str = "familydisplay") -> dict:
             "elements": []
         }
     
-    icon_theme = layout.get("meta", {}).get("iconTheme", DEFAULT_ICON_THEME)
-    
     city = DEFAULT_CITY
     if CITY_MODE == "fetch":
         city = layout.get("meta", {}).get("city", DEFAULT_CITY)
-    
+
     weather = await get_weather(city)
-    icon_code = weather.get("icon", "01d")
-    weather["icon_theme"] = icon_theme
-    weather["icon_url"] = resolve_weather_icon_url(icon_theme, icon_code)
+    if not weather.get("icon_url"):
+        weather["icon_url"] = make_public_url(FALLBACK_WEATHER_ICON)
     weather["city"] = city
-    
+
+    tz_offset = weather.get("timezone_offset")
+    now_utc = datetime.now(timezone.utc)
+    if isinstance(tz_offset, (int, float)):
+        city_tz = timezone(timedelta(seconds=int(tz_offset)), name=city)
+        now = now_utc.astimezone(city_tz)
+    else:
+        now = now_utc
+    weather["local_datetime"] = now.isoformat()
+
     dad_joke = await get_joke()
 
     layout_meta = layout.get("meta", {}) if isinstance(layout, dict) else {}
@@ -473,7 +592,6 @@ async def build_render_data(device: str = "familydisplay") -> dict:
                 "categories": categories,
             }
     
-    now = datetime.now()
     date_str = now.strftime("%a, %d %b")
     
     if storage_enabled:
@@ -719,50 +837,6 @@ def list_presets():
             logger.info(f"Using {len(presets)} local presets")
 
     return {"presets": presets, "base_url": base_url}
-
-
-def _discover_local_weather_themes() -> list[str]:
-    base_dir = Path("backend/web/designer/weather-icons")
-    if not base_dir.exists():
-        return []
-    return sorted([p.name for p in base_dir.iterdir() if p.is_dir()])
-
-
-@app.get("/api/list-weather-themes")
-def list_weather_themes():
-    """List available weather icon themes"""
-    themes: list[str] = []
-    icon_base = None
-
-    if storage_enabled:
-        try:
-            blobs = gcs_bucket.list_blobs(prefix="assets/weather-icons/", delimiter="/")
-            prefixes: list[str] = []
-            for page in blobs.pages:
-                prefixes.extend(page.prefixes)
-            themes = [
-                prefix.rstrip("/").split("/")[-1]
-                for prefix in prefixes
-            ]
-            if themes:
-                icon_base = "/gcs/assets/weather-icons"
-        except Exception as e:
-            logger.error(f"Failed to list weather themes from GCS: {e}")
-
-    if not themes:
-        themes = _discover_local_weather_themes()
-        if themes:
-            icon_base = "/designer/weather-icons"
-
-    if not themes:
-        themes = ["happy-skies", "soft-skies", "sunny-day", "blue-sky-pro"]
-
-    if icon_base is None:
-        icon_base = "/gcs/assets/weather-icons" if storage_enabled else "/designer/weather-icons"
-
-    return {"themes": themes, "icon_base": icon_base}
-
-
 @app.get("/api/pexels/categories")
 def list_pexels_categories():
     """Expose available Pexels categories to the designer"""

--- a/backend/web/designer/overlay_designer_v3_full.html
+++ b/backend/web/designer/overlay_designer_v3_full.html
@@ -572,26 +572,6 @@ button:disabled:hover {
     </div>
   </div>
 
-  <!-- --- Add Weather Modal --- -->
-  <div class="modal-overlay hidden" id="addWeatherModal">
-    <div class="modal-content">
-      <div class="modal-header">
-        <div class="modal-title">
-          <h2>Add Weather Icon</h2>
-          <p>Select icon theme</p>
-        </div>
-      </div>
-      <div class="modal-body">
-        <div class="selector-grid" id="weatherThemeSelector">
-          <!-- Content will be populated by JS -->
-        </div>
-      </div>
-      <div class="modal-footer">
-        <button id="cancelAddWeather">Cancel</button>
-      </div>
-    </div>
-  </div>
-
   <!-- --- Header --- -->
   <header>
     <div class="brand">
@@ -954,15 +934,12 @@ let availableSVGs = [];
 let availableInfoTypes = [];
 let renderData = null;
 let svgLibraryBase = '/gcs/assets/svgs';
-let weatherIconBase = '/gcs/assets/weather-icons';
 let presetBaseUrl = '';
 const FALLBACK_WEATHER_ICON = '/designer/svgs/weather_card_blue.svg';
 const DEFAULT_PEXELS_CATEGORIES = ['abstract', 'geometric', 'kids-shapes', 'minimal', 'paper-collage'];
 const pexelsCategorySelect = document.getElementById('pexelsCategorySelect');
 let availablePexelsCategories = [...DEFAULT_PEXELS_CATEGORIES];
 let currentPexelsCategory = availablePexelsCategories[0] || '';
-let currentWeatherTheme = 'happy-skies';
-let availableWeatherThemes = [];
 let fineMovementActive = false;
 
 // --- Setup Modal Logic ---
@@ -1181,6 +1158,9 @@ function getDynamicTextForType(type) {
 
   switch (type) {
     case 'TEMP':
+      if (weather.temp_min != null && weather.temp_max != null) {
+        return `${weather.temp_min}° / ${weather.temp_max}°`;
+      }
       return weather.temp != null ? `${weather.temp}°C` : '--°C';
     case 'FEELS_LIKE':
       return weather.feels_like != null ? `${weather.feels_like}°C` : '--°C';
@@ -1232,42 +1212,6 @@ function applyDynamicTextToCanvas() {
   elements.forEach(applyDynamicTextToElement);
 }
 
-function updateWeatherThemeSelection() {
-  const selector = document.getElementById('weatherThemeSelector');
-  if (!selector) return;
-
-  selector.querySelectorAll('.selector-item[data-placeholder="true"]').forEach(item => {
-    const theme = item.dataset.theme;
-    if (!theme) return;
-    const occurrences = selector.querySelectorAll(`.selector-item[data-theme="${theme}"]`);
-    if (occurrences.length > 1) {
-      item.remove();
-    }
-  });
-
-  if (currentWeatherTheme && !selector.querySelector(`.selector-item[data-theme="${currentWeatherTheme}"]`)) {
-    const placeholder = document.createElement('div');
-    placeholder.className = 'selector-item selected';
-    placeholder.dataset.theme = currentWeatherTheme;
-    placeholder.dataset.placeholder = 'true';
-    placeholder.innerHTML = `
-      <div class="selector-item-icon">🌤</div>
-      <div class="selector-item-label">${currentWeatherTheme}</div>
-    `;
-    selector.prepend(placeholder);
-  }
-
-  selector.querySelectorAll('.selector-item').forEach(item => {
-    const theme = item.dataset.theme;
-    if (!theme) return;
-    if (theme === currentWeatherTheme) {
-      item.classList.add('selected');
-    } else {
-      item.classList.remove('selected');
-    }
-  });
-}
-
 function drawGrid() {
   gridOverlay.innerHTML = '';
   const w = 800;
@@ -1300,10 +1244,32 @@ function buildSvgUrl(svgName) {
   return `${base}/${svgName.replace(/^\//, '')}`;
 }
 
-function buildWeatherIconUrl(theme, code = '01d') {
-  const safeTheme = theme || 'happy-skies';
-  const base = (weatherIconBase || '/gcs/assets/weather-icons').replace(/\/$/, '');
-  return `${base}/${safeTheme}/${code}.svg`;
+function buildWeatherIconPreviewMarkup(url) {
+  const safeUrl = (url || FALLBACK_WEATHER_ICON).replace(/"/g, '&quot;');
+  return `<img src="${safeUrl}" alt="Weather icon" style="width:100%;height:100%;object-fit:contain;pointer-events:none;" />`;
+}
+
+function getWeatherIconPreviewUrl() {
+  const direct = renderData?.weather?.icon_url;
+  if (direct && typeof direct === 'string') {
+    return direct;
+  }
+
+  const iconCode = renderData?.weather?.icon;
+  if (iconCode) {
+    return `https://openweathermap.org/img/wn/${iconCode}@4x.png`;
+  }
+
+  return FALLBACK_WEATHER_ICON;
+}
+
+function refreshWeatherIconPreviews() {
+  const previewUrl = getWeatherIconPreviewUrl();
+  const markup = buildWeatherIconPreviewMarkup(previewUrl);
+  canvas.querySelectorAll('.el[data-src="weather-icon"]').forEach(el => {
+    el.innerHTML = markup;
+    el.dataset.previewSrc = previewUrl;
+  });
 }
 
 // --- Data Fetching ---
@@ -1316,11 +1282,6 @@ async function fetchRenderData() {
     renderData = await response.json();
     if (renderData.svg_base) {
       svgLibraryBase = renderData.svg_base;
-    }
-
-    const themeFromLayout = renderData?.layout?.meta?.iconTheme;
-    if (themeFromLayout) {
-      currentWeatherTheme = themeFromLayout;
     }
 
     const metaCategory = renderData?.layout?.meta?.pexelsCategory;
@@ -1344,6 +1305,7 @@ async function fetchRenderData() {
 
     updateInfoTypeDropdown();
     applyDynamicTextToCanvas();
+    refreshWeatherIconPreviews();
     return renderData;
   } catch (error) {
     console.warn('Failed to fetch render data:', error.message);
@@ -1543,6 +1505,32 @@ function clearResizeHandles(el) {
   el.querySelectorAll('.resize-handle').forEach(handle => handle.remove());
 }
 
+function computeElementLayer(el) {
+  if (!el) return 10;
+  if (el.classList.contains('text') || el.classList.contains('icon')) {
+    return 30;
+  }
+
+  if (el.classList.contains('svg-overlay')) {
+    const src = (el.dataset.src || el.dataset.svgName || '').toString();
+    if (src === 'weather-icon' || src.startsWith('weather-')) {
+      return 35;
+    }
+    return 20;
+  }
+
+  if (el.classList.contains('box')) {
+    return 15;
+  }
+
+  return 10;
+}
+
+function applyElementLayer(el) {
+  if (!el) return;
+  el.style.zIndex = String(computeElementLayer(el));
+}
+
 function startResize(e, handleType) {
   e.stopPropagation();
   isResizing = true;
@@ -1627,9 +1615,8 @@ function addElement(kind, x, y, w, h, options = {}) {
   el.style.width = w + 'px';
   el.style.height = h + 'px';
   el.style.opacity = options.opacity !== undefined ? options.opacity : 1;
-  el.style.zIndex = '10'; // All elements on same z-index, selection outline handles visibility
   el.dataset.rotation = options.rotation || 0;
-  
+
   if (actualKind === 'text' || actualKind === 'icon') {
     const content = document.createElement('div');
     content.className = 'el-content';
@@ -1666,7 +1653,21 @@ function addElement(kind, x, y, w, h, options = {}) {
     el.dataset.gradEnd = options.gradEnd || '#1a6ec0';
     el.dataset.gradAngle = options.gradAngle || 135;
     el.dataset.svgName = options.svgName || 'svg';
-    
+
+    let srcValue = options.src;
+    if (!srcValue && options.svgName && options.svgName.startsWith('weather-')) {
+      srcValue = 'weather-icon';
+    }
+    if (srcValue && srcValue.startsWith('weather-')) {
+      srcValue = 'weather-icon';
+    }
+    if (srcValue) {
+      el.dataset.src = srcValue;
+    }
+    if (options.previewSrc) {
+      el.dataset.previewSrc = options.previewSrc;
+    }
+
     const svg = el.querySelector('svg');
     if (svg) {
       svg.style.width = '100%';
@@ -1678,7 +1679,8 @@ function addElement(kind, x, y, w, h, options = {}) {
     updateSVGContent(el);
     console.log('Created SVG element:', options.svgName);
   }
-  
+
+  applyElementLayer(el);
   canvas.appendChild(el);
   console.log('Element appended to canvas. Total elements:', canvas.querySelectorAll('.el').length);
   selectEl(el);
@@ -1920,73 +1922,6 @@ async function applyTemplate(key) {
   setStatus('Failed to load preset', 2000, true);
 }
 
-async function loadWeatherThemes() {
-  try {
-    const response = await fetch('/api/list-weather-themes');
-    if (!response.ok) throw new Error('Failed to list weather themes');
-
-    const data = await response.json();
-    weatherIconBase = data.icon_base || weatherIconBase;
-    let themes = data.themes || [];
-    if (!themes.length) {
-      themes = ['happy-skies', 'soft-skies', 'sunny-day', 'blue-sky-pro'];
-    }
-    availableWeatherThemes = themes;
-
-    const themeEmojis = {
-      'happy-skies': '😊',
-      'soft-skies': '🌈',
-      'sunny-day': '☀️',
-      'blue-sky-pro': '🌤'
-    };
-    
-    const themeLabels = {
-      'happy-skies': 'Happy Skies',
-      'soft-skies': 'Soft Skies',
-      'sunny-day': 'Sunny Day',
-      'blue-sky-pro': 'Blue Sky Pro'
-    };
-    
-    const selector = document.getElementById('weatherThemeSelector');
-    selector.innerHTML = ''; // Clear previous
-    
-    themes.forEach(theme => {
-      const item = document.createElement('div');
-      item.className = 'selector-item';
-      item.dataset.theme = theme;
-      item.innerHTML = `
-        <div class="selector-item-icon">${themeEmojis[theme] || '🌤'}</div>
-        <div class="selector-item-label">${themeLabels[theme] || theme}</div>
-      `;
-      // Click listener is now added in the 'quickAddIcon' listener
-      selector.appendChild(item);
-    });
-
-    updateWeatherThemeSelection();
-    console.log('Loaded weather themes:', themes, 'base:', weatherIconBase);
-    document.getElementById('quickAddIcon').disabled = false;
-  } catch (error) {
-    console.error('Failed to load weather themes:', error);
-    weatherIconBase = '/designer/weather-icons';
-    const fallbackThemes = ['happy-skies', 'soft-skies', 'sunny-day', 'blue-sky-pro'];
-    availableWeatherThemes = fallbackThemes;
-    const selector = document.getElementById('weatherThemeSelector');
-    selector.innerHTML = '';
-    fallbackThemes.forEach(theme => {
-      const item = document.createElement('div');
-      item.className = 'selector-item';
-      item.dataset.theme = theme;
-      item.innerHTML = `
-        <div class="selector-item-icon">🌤</div>
-        <div class="selector-item-label">${theme}</div>
-      `;
-      selector.appendChild(item);
-    });
-    updateWeatherThemeSelection();
-    document.getElementById('quickAddIcon').disabled = false;
-  }
-}
-
 async function loadSVGLibrary() {
   try {
     const response = await fetch('/api/list-svgs');
@@ -2073,7 +2008,16 @@ function exportToJSON() {
       const svgName = el.dataset.svgName || 'svg';
       base.kind = 'svg';
       base.svgName = svgName;
-      base.src = svgName;
+      const storedSrc = el.dataset.src || svgName;
+      base.src = storedSrc;
+      if (storedSrc === 'weather-icon' || svgName.startsWith('weather-')) {
+        base.svgName = 'weather-icon';
+        base.src = 'weather-icon';
+        base.fillType = 'none';
+        if (el.dataset.previewSrc) {
+          base.previewSrc = el.dataset.previewSrc;
+        }
+      }
       base.fillType = el.dataset.fillType || 'none';
       if (base.fillType === 'solid') {
         base.fillColor = el.dataset.fillColor;
@@ -2094,7 +2038,6 @@ function exportToJSON() {
     meta: {
       width: 800,
       height: 480,
-      iconTheme: currentWeatherTheme || renderData?.layout?.meta?.iconTheme || 'happy-skies', // This should be editable
       pexelsCategory: selectedCategory || null
     },
     elements: elements
@@ -2107,18 +2050,6 @@ async function loadFromJSON(data) {
   
   if (data.meta && data.meta.name) {
     currentPresetName = data.meta.name;
-  }
-
-  if (data.meta && data.meta.iconTheme) {
-    currentWeatherTheme = data.meta.iconTheme;
-  } else {
-    const weatherElement = (data.elements || []).find(el => {
-      const name = el.svgName || el.src || '';
-      return typeof name === 'string' && name.startsWith('weather-');
-    });
-    if (weatherElement) {
-      currentWeatherTheme = (weatherElement.svgName || weatherElement.src).replace('weather-', '') || currentWeatherTheme;
-    }
   }
 
   const metaCategory = data.meta?.pexelsCategory || '';
@@ -2137,47 +2068,53 @@ async function loadFromJSON(data) {
     const options = { ...elem };
 
     if (elementKind === 'svg') {
-      const svgName = elem.svgName || elem.src || '';
-      options.svgName = svgName;
-
-      try {
-        let svgUrl = '';
-        if (svgName && svgName.startsWith('weather-')) {
-          const theme = svgName.replace('weather-', '') || 'happy-skies';
-          svgUrl = buildWeatherIconUrl(theme);
-        } else {
-          svgUrl = buildSvgUrl(svgName);
-        }
-
-        if (svgUrl) {
-          const response = await fetch(svgUrl);
-          if (response.ok) {
-            options.svgContent = await response.text();
+      const storedSrc = elem.src || elem.svgName || '';
+      const svgName = elem.svgName || '';
+      options.svgName = svgName || storedSrc;
+      const isWeatherIcon = storedSrc === 'weather-icon' || (typeof svgName === 'string' && svgName.startsWith('weather-'));
+      if (isWeatherIcon) {
+        const preview = elem.previewSrc || getWeatherIconPreviewUrl();
+        options.svgContent = buildWeatherIconPreviewMarkup(preview);
+        options.svgName = 'weather-icon';
+        options.src = 'weather-icon';
+        options.fillType = 'none';
+        options.previewSrc = preview;
+      } else {
+        const svgTarget = svgName || storedSrc;
+        if (svgTarget) {
+          try {
+            const svgUrl = buildSvgUrl(svgTarget);
+            if (svgUrl) {
+              const response = await fetch(svgUrl);
+              if (response.ok) {
+                options.svgContent = await response.text();
+              }
+            }
+          } catch (error) {
+            console.warn('Failed to hydrate SVG element', svgTarget, error);
           }
         }
-      } catch (error) {
-        console.warn('Failed to hydrate SVG element', svgName, error);
-      }
 
-      if (!options.svgContent && FALLBACK_WEATHER_ICON) {
-        try {
-          const fallbackResponse = await fetch(FALLBACK_WEATHER_ICON);
-          if (fallbackResponse.ok) {
-            options.svgContent = await fallbackResponse.text();
+        if (!options.svgContent && FALLBACK_WEATHER_ICON) {
+          try {
+            const fallbackResponse = await fetch(FALLBACK_WEATHER_ICON);
+            if (fallbackResponse.ok) {
+              options.svgContent = await fallbackResponse.text();
+            }
+          } catch (fallbackError) {
+            console.warn('Fallback SVG load failed', fallbackError);
           }
-        } catch (fallbackError) {
-          console.warn('Fallback SVG load failed', fallbackError);
         }
       }
     }
 
     addElement(elementKind, elem.x, elem.y, elem.w, elem.h, options);
   });
-  
+
   await Promise.all(elementPromises);
   selectEl(null);
   applyDynamicTextToCanvas();
-  updateWeatherThemeSelection();
+  refreshWeatherIconPreviews();
 }
 
 async function saveToCloud() {
@@ -2372,65 +2309,17 @@ document.getElementById('cancelAddInfo').addEventListener('click', () => {
 });
 
 // Weather Icon (was quickAddIcon)
-document.getElementById('quickAddIcon').addEventListener('click', async () => {
-  const modal = document.getElementById('addWeatherModal');
-  const selector = document.getElementById('weatherThemeSelector');
-  
-  // Selector is populated by loadWeatherThemes() on init
-  
-  // Add click handlers to theme items
-  selector.querySelectorAll('.selector-item').forEach(item => {
-    const theme = item.dataset.theme;
-    if (!theme) return;
-    
-    // Clone to remove old listeners and prevent duplicates
-    const newItem = item.cloneNode(true);
-    item.replaceWith(newItem);
-    
-    newItem.addEventListener('click', async () => {
-      const svgUrl = buildWeatherIconUrl(theme);
-
-      try {
-        let svgContent = '';
-        try {
-          const response = await fetch(svgUrl);
-          if (response.ok) {
-            svgContent = await response.text();
-          } else {
-            throw new Error(`HTTP ${response.status}`);
-          }
-        } catch (networkError) {
-          console.warn('Weather icon fetch failed, using fallback', networkError);
-          const fallbackResponse = await fetch(FALLBACK_WEATHER_ICON);
-          if (fallbackResponse.ok) {
-            svgContent = await fallbackResponse.text();
-          } else {
-            throw new Error('Fallback icon not available');
-          }
-        }
-
-        currentWeatherTheme = theme;
-        updateWeatherThemeSelection();
-        addElement('svg', 100, 100, 120, 120, {
-          svgContent,
-          svgName: `weather-${theme}`,
-          fillType: 'none'
-        });
-
-        modal.classList.add('hidden');
-        setStatus(`Added weather icon: ${theme}`, 1500);
-      } catch (error) {
-        console.error('Failed to load weather icon:', error);
-        setStatus(`Failed to load icon: ${error.message}`, 2000, true);
-      }
-    });
+document.getElementById('quickAddIcon').addEventListener('click', () => {
+  const previewUrl = getWeatherIconPreviewUrl();
+  addElement('svg', 100, 100, 120, 120, {
+    svgContent: buildWeatherIconPreviewMarkup(previewUrl),
+    svgName: 'weather-icon',
+    fillType: 'none',
+    src: 'weather-icon',
+    previewSrc: previewUrl
   });
-  
-  modal.classList.remove('hidden');
-});
-
-document.getElementById('cancelAddWeather').addEventListener('click', () => {
-  document.getElementById('addWeatherModal').classList.add('hidden');
+  refreshWeatherIconPreviews();
+  setStatus('Added weather icon', 1500);
 });
 
 // --- Inspector Event Listeners ---
@@ -2481,7 +2370,8 @@ document.getElementById('duplicateBtn').addEventListener('click', () => {
   // Remove selection state from clone
   clone.classList.remove('selected');
   clone.querySelectorAll('.resize-handle').forEach(h => h.remove());
-  
+
+  applyElementLayer(clone);
   canvas.appendChild(clone);
   selectEl(clone); // Select the new clone
   saveAction('Duplicate');
@@ -2934,7 +2824,6 @@ async function init() {
   // Disable API-dependent buttons by default
   document.getElementById('applyTemplateBtn').disabled = true;
   document.getElementById('quickAddFancyBox').disabled = true;
-  document.getElementById('quickAddIcon').disabled = true;
   
   console.log('Initializing Kin:D Designer...');
   
@@ -2942,7 +2831,6 @@ async function init() {
     await Promise.all([
       loadPresets(),
       loadSVGLibrary(),
-      loadWeatherThemes(),
       loadPexelsCategories(),
       fetchRenderData()
     ]);
@@ -2952,7 +2840,7 @@ async function init() {
     }
 
     applyDynamicTextToCanvas();
-    updateWeatherThemeSelection();
+    refreshWeatherIconPreviews();
     console.log('Initialization complete.');
     setStatus('Ready', 0);
 

--- a/backend/web/layouts/base.html
+++ b/backend/web/layouts/base.html
@@ -154,7 +154,10 @@
           return data.weather?.city || "City";
         
         case "TEMP":
-          return data.weather?.temp != null 
+          if (data.weather?.temp_min != null && data.weather?.temp_max != null) {
+            return `${data.weather.temp_min}° / ${data.weather.temp_max}°`;
+          }
+          return data.weather?.temp != null
             ? data.weather.temp + "°C"
             : "--°C";
         
@@ -177,7 +180,28 @@
 
         default:
           return el.text || "";
+    }
+    }
+
+    function getLayerZIndex(el, providedKind) {
+      const kind = (providedKind || el.kind || "").toLowerCase();
+      if (kind === "text" || kind === "icon") {
+        return 30;
       }
+
+      if (kind === "svg" || kind === "svg-overlay" || kind === "image") {
+        const source = String(el.src || el.svgName || "");
+        if (source === "weather-icon" || source.startsWith("weather-")) {
+          return 35;
+        }
+        return 20;
+      }
+
+      if (kind === "box") {
+        return 15;
+      }
+
+      return 10;
     }
 
     /**
@@ -268,6 +292,7 @@
         if (el.opacity != null) div.style.opacity = el.opacity;
 
         const kind = (el.kind || "").toLowerCase();
+        div.style.zIndex = getLayerZIndex(el, kind);
 
         // ============================================================
         // TEXT ELEMENTS


### PR DESCRIPTION
## Summary
- cache OpenWeather icons in GCS when available and reuse them when building render data
- remove weather icon theme selection from the designer in favor of dynamic OpenWeather previews and stored preview metadata
- keep designer and layout exports resilient with fallback icons when OpenWeather data is unavailable

## Testing
- python -m compileall backend

------
https://chatgpt.com/codex/tasks/task_e_690937d935a4832ca0ab09e83e42854e