### PR TITLE
Fix PlatformIO source directory configuration

### DIFF
--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -21,6 +21,9 @@ platform = espressif32
 board = esp32dev
 framework = arduino
 
+; Source directory (where .ino and .cpp files are located)
+src_dir = KindDisplay
+
 ; Serial monitor settings
 monitor_speed = 115200
 monitor_filters =


### PR DESCRIPTION
- Add src_dir = KindDisplay to platformio.ini
- Resolves build error: 'Nothing to build'
- Points PlatformIO to correct source location