### PR TITLE
Fix src_dir configuration in platformio.ini

### DIFF
--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -16,13 +16,14 @@
 ;
 ; ============================================================
 
+[platformio]
+; Source directory (where .ino and .cpp files are located)
+src_dir = KindDisplay
+
 [env:esp32dev]
 platform = espressif32
 board = esp32dev
 framework = arduino
-
-; Source directory (where .ino and .cpp files are located)
-src_dir = KindDisplay
 
 ; Serial monitor settings
 monitor_speed = 115200


### PR DESCRIPTION
- Move src_dir to [platformio] section (correct location)
- Remove from [env:esp32dev] section (invalid location)
- Resolves 'unknown configuration option' warning