### PR TITLE
Fix pre-existing compilation errors in QR and RAW7 modules

### DIFF
--- a/firmware/KindDisplay/qr_display.cpp
+++ b/firmware/KindDisplay/qr_display.cpp
@@ -1,5 +1,5 @@
 #include "qr_display.h"
-#include "qrcode.h"  // Using ricmoo/qrcode library
+#include <qrcode.h>  // Using ricmoo/qrcode library
 
 void QRDisplay::showSetupScreen(SpectraDisplay& display) {
     DEBUG_PRINTLN("QR: Rendering setup screen");

--- a/firmware/KindDisplay/raw7_decoder.h
+++ b/firmware/KindDisplay/raw7_decoder.h
@@ -3,6 +3,7 @@
 
 #include <Arduino.h>
 #include <HTTPClient.h>
+#include <WiFiClient.h>
 #include "config.h"
 
 // ============================================================


### PR DESCRIPTION
- raw7_decoder.h: Add missing WiFiClient.h include
- qr_display.cpp: Fix QRCode library include (use angle brackets)

These were pre-existing issues not related to the 8 new features.