### PR TITLE
Fix critical GPIO pin conflict and SPI initialization issues in ESP32 firmware

### DIFF
--- a/firmware/KindDisplay/config.h
+++ b/firmware/KindDisplay/config.h
@@ -40,7 +40,7 @@
 // SD Card pins (using default VSPI)
 #define PIN_SD_CS     13  // Adjust based on your hardware
 #define PIN_SD_MOSI   15
-#define PIN_SD_MISO   2
+#define PIN_SD_MISO   19  // FIXED: Was GPIO2 (conflicted with LED), now GPIO19 (standard VSPI MISO)
 #define PIN_SD_SCK    14
 
 // ============================================================

--- a/firmware/KindDisplay/display_driver.cpp
+++ b/firmware/KindDisplay/display_driver.cpp
@@ -32,7 +32,8 @@ bool SpectraDisplay::begin() {
     digitalWrite(PIN_EPD_DC, HIGH);
 
     // Initialize SPI
-    SPI.begin(PIN_EPD_SCK, -1, PIN_EPD_MOSI, PIN_EPD_CS);
+    // Note: EPD is write-only, so MISO = -1, and we control CS manually, so SS = -1
+    SPI.begin(PIN_EPD_SCK, -1, PIN_EPD_MOSI, -1);
     SPI.beginTransaction(SPISettings(4000000, MSBFIRST, SPI_MODE0));
 
     // Hardware reset

--- a/firmware/README.md
+++ b/firmware/README.md
@@ -159,9 +159,11 @@ The e-ink dev board includes a built-in 3-position switch:
 Default VSPI pins for SD card:
 - **CS**: GPIO 13
 - **MOSI**: GPIO 15
-- **MISO**: GPIO 2
+- **MISO**: GPIO 19 (Standard VSPI MISO pin)
 - **SCK**: GPIO 14
 
+> **Note**: Previous versions incorrectly used GPIO 2 for MISO, which conflicted with the status LED. This has been fixed to use the standard VSPI MISO pin (GPIO 19).
+>
 > These can be adjusted in `config.h` if your board uses different pins.
 
 ## 🚀 Getting Started


### PR DESCRIPTION
This commit fixes two critical bugs that prevented the ESP32 from functioning correctly:

1. **GPIO Pin Conflict**: PIN_STATUS_LED and PIN_SD_MISO were both assigned to GPIO2,
   causing a hardware conflict. Changed PIN_SD_MISO to GPIO19 (standard VSPI MISO pin).

2. **SPI Initialization**: Fixed SPI.begin() call to use correct parameters for manual
   chip select control. The SS parameter should be -1 when controlling CS manually.

Changes:
- firmware/KindDisplay/config.h: Changed PIN_SD_MISO from GPIO2 to GPIO19
- firmware/KindDisplay/display_driver.cpp: Fixed SPI.begin() call to use -1 for SS parameter
- firmware/README.md: Updated documentation to reflect corrected SD card MISO pin

These fixes resolve the "red screen" error that occurs when the firmware encounters
initialization failures due to the GPIO conflict.