### PR TITLE
Temporarily disable QR display to fix out-of-memory crash

### DIFF
--- a/firmware/KindDisplay/KindDisplay.ino
+++ b/firmware/KindDisplay/KindDisplay.ino
@@ -184,8 +184,13 @@ void handleFirstBoot() {
     DEBUG_PRINTLN("\n=== FIRST BOOT / SETUP MODE ===");
 
     // Show QR code setup screen on display
-    QRDisplay::showSetupScreen(display);
-    display.powerOff();
+    // TEMPORARILY DISABLED - causes out of memory crash
+    // QRDisplay::showSetupScreen(display);
+    // display.powerOff();
+
+    DEBUG_PRINTLN("QR display disabled to save memory");
+    DEBUG_PRINTLN("Connect to WiFi: KIND-Setup (password: kind1234)");
+    DEBUG_PRINTLN("Visit: http://192.168.4.1");
 
     // Start WiFi configuration portal with LED slow blink
     wifiMgr.startConfigPortal(&statusLED);  // NEW: Pass LED for slow blink


### PR DESCRIPTION
The QR display code allocates 576KB of RAM (384KB + 192KB buffers) which exceeds the ESP32's available memory (~520KB total), causing a crash on first boot with the red LED stuck on.

Changes:
- Disabled QRDisplay::showSetupScreen() in handleFirstBoot()
- Added serial debug messages with WiFi setup instructions
- Users can still configure WiFi via the web portal at 192.168.4.1

This is a temporary workaround. The QR display will need to be optimized to use less memory (e.g., use PSRAM, stream to display instead of buffering, or reduce QR code size).

Fixes: Red LED stuck on, ESP32 crash on first boot