### PR TITLE
Fix SD card SPI bus conflict with display

### DIFF
--- a/firmware/KindDisplay/config.h
+++ b/firmware/KindDisplay/config.h
@@ -37,11 +37,11 @@
 #define PIN_BATTERY_ADC    36  // Change this to your actual battery sense pin
 #define BATTERY_ENABLED    true  // Set to false to disable battery monitoring
 
-// SD Card pins (using default VSPI)
-#define PIN_SD_CS     13  // Adjust based on your hardware
-#define PIN_SD_MOSI   15
-#define PIN_SD_MISO   19  // FIXED: Was GPIO2 (conflicted with LED), now GPIO19 (standard VSPI MISO)
-#define PIN_SD_SCK    14
+// SD Card pins (sharing VSPI with display, different CS)
+#define PIN_SD_CS     13  // Separate chip select for SD card
+#define PIN_SD_MOSI   23  // Shared with display (VSPI MOSI)
+#define PIN_SD_MISO   19  // VSPI MISO
+#define PIN_SD_SCK    18  // Shared with display (VSPI SCK)
 
 // ============================================================
 // NETWORK CONFIGURATION

--- a/firmware/KindDisplay/sd_manager.cpp
+++ b/firmware/KindDisplay/sd_manager.cpp
@@ -6,9 +6,8 @@ SDManager::SDManager() : _initialized(false), _csPin(PIN_SD_CS) {
 bool SDManager::begin() {
     DEBUG_PRINTLN("SD: Initializing SD card");
 
-    // Initialize SPI for SD card
-    SPI.begin(PIN_SD_SCK, PIN_SD_MISO, PIN_SD_MOSI, _csPin);
-
+    // SPI already initialized by display driver
+    // SD card shares the same SPI bus, just uses different CS pin
     if (!SD.begin(_csPin)) {
         DEBUG_PRINTLN("SD: Card mount failed or not present");
         _initialized = false;


### PR DESCRIPTION
The SD card and display were trying to use different SPI pin configurations, causing the SD card initialization to hang.

Root cause:
- Display initialized VSPI with SCK=18, MOSI=23
- SD card tried to re-initialize with SCK=14, MOSI=15
- Calling SPI.begin() twice with different pins causes conflict

Solution:
- SD card now shares VSPI bus with display (SCK=18, MOSI=23, MISO=19)
- Both devices use different CS pins (Display: GPIO5, SD: GPIO13)
- Removed redundant SPI.begin() call from sd_manager.cpp

This is the standard approach for multiple SPI devices on ESP32.