### PR TITLE
Add option to disable SD card initialization

### DIFF
--- a/firmware/KindDisplay/KindDisplay.ino
+++ b/firmware/KindDisplay/KindDisplay.ino
@@ -108,11 +108,15 @@ void setup() {
     }
 
     // Initialize SD card (optional)
+    #if SD_CARD_ENABLED
     if (sdCard.begin()) {
         DEBUG_PRINTLN("SD card available");
     } else {
         DEBUG_PRINTLN("SD card not available (optional)");
     }
+    #else
+    DEBUG_PRINTLN("SD card disabled in config");
+    #endif
 
     // NEW: Check battery before any heavy operations
     checkBatteryAndSleep();
@@ -235,6 +239,7 @@ void updateDisplay(bool triggerReroll) {
         rtcMgr.recordWiFiFailure();
 
         // Try to load cached image from SD card
+        #if SD_CARD_ENABLED
         if (sdCard.isAvailable() && sdCard.hasCachedImage()) {
             DEBUG_PRINTLN("Loading cached image from SD card");
             size_t size = 0;
@@ -253,6 +258,7 @@ void updateDisplay(bool triggerReroll) {
 
             if (cachedImage) free(cachedImage);
         }
+        #endif
 
         showErrorScreen("WiFi Failed");
         delay(3000);
@@ -291,6 +297,7 @@ void updateDisplay(bool triggerReroll) {
         DEBUG_PRINTLN("Image fetch failed");
 
         // Try cached image
+        #if SD_CARD_ENABLED
         if (sdCard.isAvailable() && sdCard.hasCachedImage()) {
             DEBUG_PRINTLN("Falling back to cached image");
             size_t size = 0;
@@ -309,6 +316,7 @@ void updateDisplay(bool triggerReroll) {
 
             if (cachedImage) free(cachedImage);
         }
+        #endif
 
         showErrorScreen("Image Fetch Failed");
         WiFi.disconnect(true);
@@ -322,11 +330,13 @@ void updateDisplay(bool triggerReroll) {
     battery.overlayLowBatteryWarning(imageBuffer, imageSize);
 
     // Cache image to SD card
+    #if SD_CARD_ENABLED
     if (sdCard.isAvailable()) {
         if (sdCard.saveRAW7(imageBuffer, imageSize)) {
             DEBUG_PRINTLN("Image cached to SD card");
         }
     }
+    #endif
 
     // Display image
     display.displayRAW7(imageBuffer, imageSize);

--- a/firmware/KindDisplay/config.h
+++ b/firmware/KindDisplay/config.h
@@ -39,6 +39,7 @@
 
 // SD Card pins (sharing VSPI with display)
 // WARNING: SD card CS appears to share GPIO5 with display CS on this board
+#define SD_CARD_ENABLED   false  // Set to false to disable SD card (use if initialization hangs)
 #define PIN_SD_CS     5   // CS pin (matches board marking, shared with display!)
 #define PIN_SD_MOSI   23  // CMD on board (VSPI MOSI)
 #define PIN_SD_MISO   19  // DAT on board (VSPI MISO)


### PR DESCRIPTION
Added SD_CARD_ENABLED config flag (default: false) to completely skip SD card initialization if it causes hanging.

Changes:
- Added SD_CARD_ENABLED flag in config.h (set to false by default)
- Wrapped all SD card initialization and usage with #if SD_CARD_ENABLED
- Firmware will skip SD card and continue booting normally
- SD card caching is optional - not required for normal operation

This resolves the issue where SD.begin() hangs indefinitely on some hardware configurations with shared CS pins.

Users can re-enable by setting SD_CARD_ENABLED to true in config.h