### PR TITLE
Fix SD card initialization hang by properly sharing SPI bus

### DIFF
--- a/firmware/KindDisplay/display_driver.cpp
+++ b/firmware/KindDisplay/display_driver.cpp
@@ -31,9 +31,10 @@ bool SpectraDisplay::begin() {
     digitalWrite(PIN_EPD_CS, HIGH);
     digitalWrite(PIN_EPD_DC, HIGH);
 
-    // Initialize SPI
-    // Note: EPD is write-only, so MISO = -1, and we control CS manually, so SS = -1
-    SPI.begin(PIN_EPD_SCK, -1, PIN_EPD_MOSI, -1);
+    // Initialize SPI with all pins (including MISO for SD card compatibility)
+    // EPD is write-only, but we share SPI bus with SD card which needs MISO
+    // We control CS manually, so SS = -1
+    SPI.begin(PIN_EPD_SCK, PIN_SD_MISO, PIN_EPD_MOSI, -1);
     SPI.beginTransaction(SPISettings(4000000, MSBFIRST, SPI_MODE0));
 
     // Hardware reset

--- a/firmware/KindDisplay/sd_manager.cpp
+++ b/firmware/KindDisplay/sd_manager.cpp
@@ -6,10 +6,12 @@ SDManager::SDManager() : _initialized(false), _csPin(PIN_SD_CS) {
 bool SDManager::begin() {
     DEBUG_PRINTLN("SD: Initializing SD card");
 
-    // Re-initialize SPI with SD card parameters
-    // Even though display uses same pins, SD.begin() needs SPI configured
-    SPI.begin(PIN_SD_SCK, PIN_SD_MISO, PIN_SD_MOSI, PIN_SD_CS);
+    // SPI already initialized by display - don't re-initialize
+    // Just set up the CS pin for SD card
+    pinMode(_csPin, OUTPUT);
+    digitalWrite(_csPin, HIGH);  // CS idle high
 
+    // Initialize SD card library (SPI already configured)
     if (!SD.begin(_csPin, SPI, 4000000)) {  // 4MHz for compatibility
         DEBUG_PRINTLN("SD: Card mount failed or not present");
         _initialized = false;


### PR DESCRIPTION
Issue: SD card initialization was hanging because SPI bus was being initialized twice with incompatible parameters.

Root cause:
- Display initialized SPI with MISO=-1 (display is write-only)
- SD card tried to re-initialize SPI with MISO=27 (SD needs MISO)
- SPI can only be initialized once; re-initialization causes conflicts

Solution:
1. Display now initializes SPI with all pins including MISO (GPIO27)
   - Display doesn't use MISO but SD card on shared bus does
   - This allows both devices to coexist on same SPI bus

2. SD card manager no longer re-initializes SPI
   - Only sets up CS pin (GPIO13) as output
   - Uses existing SPI configuration from display

Changes:
- display_driver.cpp: Changed SPI.begin() to include PIN_SD_MISO
- sd_manager.cpp: Removed SPI.begin() call, added pinMode/digitalWrite for CS

Shared SPI bus configuration:
- SCK: GPIO18 (shared)
- MOSI: GPIO19 (shared)
- MISO: GPIO27 (SD only, but initialized for both)
- Display CS: GPIO5
- SD Card CS: GPIO13 (separate)

This fix ensures SD card can initialize without conflicts while maintaining display functionality.