### PR TITLE
Disable switch wakeup to fix boot loop

### DIFF
--- a/firmware/KindDisplay/KindDisplay.ino
+++ b/firmware/KindDisplay/KindDisplay.ino
@@ -400,8 +400,11 @@ void enterDeepSleep() {
     // NEW: Turn off LED before sleep (Part 1)
     statusLED.off();
 
-    // Enable button wake (optional for switch monitoring)
-    button.enableWakeup();
+    // Disable button wake - causes boot loop with level-triggered wakeup
+    // The switch uses level detection (ANY_HIGH) which triggers immediately
+    // when the switch is in NORMAL (GPIO34=HIGH) or SPECIAL (GPIO35=HIGH) position
+    // Relying on timer wake instead (primary wake method)
+    // button.enableWakeup();  // DISABLED - causes boot loop
 
     // Calculate and enter deep sleep
     rtcMgr.sleepUntilWake();


### PR DESCRIPTION
Issue: Device was stuck in continuous boot loop, waking up every few seconds and immediately going back to sleep with "EXT1" wake reason.

Root cause:
- Switch wakeup configured as ESP_EXT1_WAKEUP_ANY_HIGH
- This wakes when either GPIO34 OR GPIO35 is HIGH
- NORMAL mode: GPIO34=HIGH (always triggers wakeup!)
- SPECIAL mode: GPIO35=HIGH (always triggers wakeup!)
- Device sleeps → Pin still HIGH → Immediately wakes → Repeats

The level-triggered wakeup causes immediate wake in both valid switch positions because one pin is always HIGH in any valid mode.

Solution:
Disabled button.enableWakeup() call before deep sleep. Device now relies solely on timer-based wakeup (primary wake method) which works correctly.

Impact:
- Device no longer wakes on switch position changes
- Still reads switch position after timer wake
- Prevents boot loop
- Battery life improved (no continuous wake/sleep cycles)

Serial log showed:
- Wake Reason: EXT1 (repeating)
- Switch Mode: UNKNOWN
- Refresh throttled (only 2178ms since last)
- Immediate sleep and repeat

With this fix, device will sleep properly and wake at scheduled time.