### PR TITLE
Switch to GPIO0 for rotary wake (has 10kΩ pull-down resistor)

### DIFF
--- a/firmware/KindDisplay/KindDisplay.ino
+++ b/firmware/KindDisplay/KindDisplay.ino
@@ -97,23 +97,23 @@ void setup() {
 
     // Determine mode based on wake source
     // Rotary switch springs back to CENTER (35) after rotation
-    // UP (0) → GPIO0 (DISABLED - causes boot loop), CENTER (35) → resting, DOWN (34) → GPIO34
+    // UP (0) → GPIO0 (has 10k pull-down resistor), CENTER (35) → resting, DOWN (34) → GPIO34
     if (ButtonHandler::wasWakeSource()) {
         uint8_t wakePin = ButtonHandler::getWakePin();
         DEBUG_PRINTF("Switch: Woken by rotary switch - GPIO%d\n", wakePin);
 
-        // Only GPIO34 (DOWN) is enabled for wake
-        if (wakePin == PIN_SWITCH_34) {
+        // GPIO0 (UP) has external pull-down resistor - safe for wake
+        if (wakePin == 0) {
             // Check for factory reset (6 clicks within 10 seconds)
             if (rtcMgr.checkRotaryClicks()) {
-                DEBUG_PRINTLN("Switch: Rotated DOWN (GPIO34) → FACTORY RESET (6 clicks detected)");
+                DEBUG_PRINTLN("Switch: Rotated UP (GPIO0) → FACTORY RESET (6 clicks detected)");
                 handleFactoryReset();
                 return;  // Never returns
             }
 
             // Single click: trigger background reroll
             currentMode = MODE_SPECIAL;
-            DEBUG_PRINTLN("Switch: Rotated DOWN (GPIO34) → SPECIAL mode (background reroll)");
+            DEBUG_PRINTLN("Switch: Rotated UP (GPIO0) → SPECIAL mode (background reroll)");
         } else {
             currentMode = MODE_NORMAL;
             DEBUG_PRINTLN("Switch: Unknown wake pin → NORMAL mode (default)");

--- a/firmware/KindDisplay/button_handler.cpp
+++ b/firmware/KindDisplay/button_handler.cpp
@@ -69,17 +69,15 @@ const char* ButtonHandler::getModeString(SwitchMode mode) {
 
 void ButtonHandler::enableWakeup() {
     // Enable rotary switch wake from deep sleep
-    // Rotary positions: UP=GPIO0, CENTER=resting, DOWN=GPIO34
-    // Note: GPIO0 DISABLED for wake - causes boot loop (boot mode pin with pull-up)
-    // Only GPIO34 (DOWN) is used for manual wake
+    // Using GPIO0 (UP position) which has external 10kΩ pull-down (SMD "103")
+    // Pull-down prevents boot loop - GPIO0 is LOW at rest, HIGH only during rotation
 
     const uint64_t ext_wakeup_pin_mask =
-        (1ULL << PIN_SWITCH_34);   // GPIO34 for DOWN rotation only
+        (1ULL << 0);   // GPIO0 for UP rotation (has pull-down resistor)
 
     esp_sleep_enable_ext1_wakeup(ext_wakeup_pin_mask, ESP_EXT1_WAKEUP_ANY_HIGH);
 
-    DEBUG_PRINTF("Switch: Wake enabled on GPIO%d (DOWN only - GPIO0 disabled due to boot loop)\n",
-                 PIN_SWITCH_34);
+    DEBUG_PRINTF("Switch: Wake enabled on GPIO0 (UP rotation - has 10k pull-down)\n");
 }
 
 bool ButtonHandler::wasWakeSource() {


### PR DESCRIPTION
GPIO34 was also causing boot loops. Switching to GPIO0 which has an external 10kΩ pull-down resistor (SMD component marked "103").

Hardware discovery:
- GPIO0 has SMD resistor "103" = 10kΩ (10 + 3 zeros)
- Likely connected between GPIO0 and GND (pull-down)
- Pull-down keeps GPIO0 LOW at rest, preventing boot loops
- GPIO0 only goes HIGH during momentary rotation

Benefits of pull-down resistor:
- GPIO0 rests at LOW (safe boot condition)
- Triggers HIGH only when switch rotated UP
- Returns to LOW immediately when released
- No boot loop like GPIO34 (which has pull-up or floating)

Rotary switch behavior:
- Rotate UP → GPIO0 wake → background reroll (1 click) or factory reset (6 clicks)
- Timer wake → normal refresh
- GPIO34 and GPIO35 no longer used for wake detection

This should eliminate the boot loop while maintaining all functionality.