### PR TITLE
Use EXT0 wake for center press button (GPIO35) to avoid boot loop

### DIFF
--- a/firmware/KindDisplay/KindDisplay.ino
+++ b/firmware/KindDisplay/KindDisplay.ino
@@ -97,28 +97,21 @@ void setup() {
     button.begin();
 
     // Determine mode based on wake source
-    // Rotary switch springs back to CENTER (35) after rotation
-    // UP (0) → GPIO0 (has 10k pull-down resistor), CENTER (35) → resting, DOWN (34) → GPIO34
+    // Center press button (GPIO35) for manual wake
     if (ButtonHandler::wasWakeSource()) {
         uint8_t wakePin = ButtonHandler::getWakePin();
-        DEBUG_PRINTF("Switch: Woken by rotary switch - GPIO%d\n", wakePin);
+        DEBUG_PRINTF("Switch: Woken by press button - GPIO%d\n", wakePin);
 
-        // GPIO0 (UP) has external pull-down resistor - safe for wake
-        if (wakePin == 0) {
-            // Check for factory reset (6 clicks within 10 seconds)
-            if (rtcMgr.checkRotaryClicks()) {
-                DEBUG_PRINTLN("Switch: Rotated UP (GPIO0) → FACTORY RESET (6 clicks detected)");
-                handleFactoryReset();
-                return;  // Never returns
-            }
-
-            // Single click: trigger background reroll
-            currentMode = MODE_SPECIAL;
-            DEBUG_PRINTLN("Switch: Rotated UP (GPIO0) → SPECIAL mode (background reroll)");
-        } else {
-            currentMode = MODE_NORMAL;
-            DEBUG_PRINTLN("Switch: Unknown wake pin → NORMAL mode (default)");
+        // Check for factory reset (6 presses within 10 seconds)
+        if (rtcMgr.checkRotaryClicks()) {
+            DEBUG_PRINTLN("Switch: Center press → FACTORY RESET (6 presses detected)");
+            handleFactoryReset();
+            return;  // Never returns
         }
+
+        // Single press: trigger background reroll
+        currentMode = MODE_SPECIAL;
+        DEBUG_PRINTLN("Switch: Center press → SPECIAL mode (background reroll)");
     } else {
         // Timer wake or other - default to normal mode
         currentMode = MODE_NORMAL;

--- a/firmware/KindDisplay/button_handler.cpp
+++ b/firmware/KindDisplay/button_handler.cpp
@@ -68,32 +68,27 @@ const char* ButtonHandler::getModeString(SwitchMode mode) {
 }
 
 void ButtonHandler::enableWakeup() {
-    // DISABLED: All GPIO wake sources disabled due to boot loop issues
-    // Both GPIO0 and GPIO34 cause immediate re-wake after deep sleep
-    // Relying on timer wake only until press-button GPIO is identified
+    // Using GPIO35 (center press) with EXT0 wakeup
+    // EXT0 supports edge triggering - wakes on LOW (button press)
+    // This avoids boot loops caused by EXT1's level-triggered behavior
 
-    // TODO: Investigate rotary "press down" button for wake source
+    #define PRESS_BUTTON_GPIO 35  // Center press button
 
-    DEBUG_PRINTLN("Switch: GPIO wake DISABLED - timer wake only (boot loop prevention)");
+    // Configure EXT0 to wake on LOW level (button press pulls to GND)
+    // Using LOW instead of falling edge because pull-up keeps it HIGH normally
+    esp_sleep_enable_ext0_wakeup((gpio_num_t)PRESS_BUTTON_GPIO, 0);  // 0 = LOW, 1 = HIGH
 
-    // No wake sources enabled - device will only wake on timer
+    DEBUG_PRINTF("Switch: Wake enabled on GPIO%d (center press button, LOW trigger)\n", PRESS_BUTTON_GPIO);
 }
 
 bool ButtonHandler::wasWakeSource() {
     esp_sleep_wakeup_cause_t wakeup_reason = esp_sleep_get_wakeup_cause();
-    return (wakeup_reason == ESP_SLEEP_WAKEUP_EXT1);
+    return (wakeup_reason == ESP_SLEEP_WAKEUP_EXT0);  // Changed from EXT1 to EXT0
 }
 
 uint8_t ButtonHandler::getWakePin() {
-    if (esp_sleep_get_wakeup_cause() == ESP_SLEEP_WAKEUP_EXT1) {
-        uint64_t wakeup_pin_mask = esp_sleep_get_ext1_wakeup_status();
-
-        if (wakeup_pin_mask & (1ULL << 0)) {
-            return 0;  // GPIO0 (UP position)
-        }
-        if (wakeup_pin_mask & (1ULL << PIN_SWITCH_34)) {
-            return PIN_SWITCH_34;  // GPIO34 (DOWN position)
-        }
+    if (esp_sleep_get_wakeup_cause() == ESP_SLEEP_WAKEUP_EXT0) {
+        return 35;  // EXT0 only supports one GPIO, we're using GPIO35 (center press)
     }
     return 255;  // Invalid/unknown
 }


### PR DESCRIPTION
Switched from EXT1 (multi-GPIO, level-triggered) to EXT0 (single GPIO) for the center press button. This eliminates boot loops.

Root cause of boot loops:
- EXT1 with ESP_EXT1_WAKEUP_ANY_HIGH is level-triggered
- If GPIO is HIGH when entering sleep, wakes immediately
- GPIO noise/capacitance keeps it HIGH briefly → boot loop
- User's test script proves buttons work fine (are truly momentary)

Solution - EXT0 wake:
- Single GPIO only (GPIO35 = center press button)
- Configure for LOW trigger (button press pulls to GND)
- GPIO normally HIGH with pull-up, goes LOW only when pressed
- No boot loop because we trigger on LOW, not HIGH

Changes:
- enableWakeup(): Use esp_sleep_enable_ext0_wakeup(GPIO35, LOW)
- wasWakeSource(): Check ESP_SLEEP_WAKEUP_EXT0 instead of EXT1
- getWakePin(): Return 35 for EXT0 wake (single GPIO only)
- Updated debug messages for center press button

Button functionality:
- Press center button → wake from sleep → background reroll
- 6 presses within 10 seconds → factory reset
- Timer wake (daily) → normal refresh

EXT0 vs EXT1:
- EXT0: Single GPIO, LOW or HIGH trigger, simpler, no boot loops
- EXT1: Multiple GPIOs, level-triggered ANY_HIGH/ALL_LOW, caused loops