### PR TITLE
Add memory diagnostics for RAW7 allocation failure

### DIFF
--- a/firmware/KindDisplay/KindDisplay.ino
+++ b/firmware/KindDisplay/KindDisplay.ino
@@ -233,6 +233,10 @@ void handleSpecialMode() {
 void updateDisplay(bool triggerReroll) {
     DEBUG_PRINTLN("\n--- Updating Display ---");
 
+    // Memory diagnostics
+    DEBUG_PRINTF("Memory: Free heap: %d bytes, Largest block: %d bytes\n",
+                 ESP.getFreeHeap(), ESP.getMaxAllocHeap());
+
     // Connect to WiFi with LED fast blink feedback
     if (!wifiMgr.connect(&statusLED)) {  // NEW: Pass LED for feedback
         DEBUG_PRINTLN("WiFi connection failed");

--- a/firmware/KindDisplay/raw7_decoder.cpp
+++ b/firmware/KindDisplay/raw7_decoder.cpp
@@ -14,12 +14,21 @@ uint8_t* RAW7Decoder::fetchImage(const char* backendUrl, const char* deviceName,
     String url = String(backendUrl) + "/v1/raw7?device=" + String(deviceName);
     DEBUG_PRINTF("RAW7: Fetching from %s\n", url.c_str());
 
+    // Check available heap before allocation
+    DEBUG_PRINTF("RAW7: Free heap before allocation: %d bytes\n", ESP.getFreeHeap());
+    DEBUG_PRINTF("RAW7: Largest free block: %d bytes\n", ESP.getMaxAllocHeap());
+    DEBUG_PRINTF("RAW7: Need to allocate: %d bytes\n", RAW7_SIZE);
+
     // Allocate buffer for RAW7 image
     uint8_t* buffer = (uint8_t*)malloc(RAW7_SIZE);
     if (!buffer) {
         DEBUG_PRINTLN("RAW7: ERROR - Memory allocation failed");
+        DEBUG_PRINTF("RAW7: Free heap: %d bytes (insufficient for %d bytes)\n",
+                     ESP.getFreeHeap(), RAW7_SIZE);
         return nullptr;
     }
+
+    DEBUG_PRINTF("RAW7: Buffer allocated successfully at 0x%08X\n", (uint32_t)buffer);
 
     // Start HTTP connection
     _http.begin(url);


### PR DESCRIPTION
Added heap diagnostics to identify why 192KB malloc() is failing:
- Show free heap before allocation in raw7_decoder.cpp
- Show largest contiguous block available
- Display memory stats at start of updateDisplay()

This will help determine if issue is:
- Insufficient total memory
- Heap fragmentation
- Need for PSRAM