### PR TITLE
Add Pillow dependency to fix RAW7 image generation

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -4,3 +4,4 @@ google-cloud-storage==2.18.2
 playwright==1.55.0
 httpx==0.27.2
 python-dateutil==2.9.0.post0
+Pillow==10.4.0


### PR DESCRIPTION
Backend was failing with "No module named 'PIL'" error when trying to generate RAW7 images. Added Pillow to requirements.txt to fix image processing functionality.