### PR TITLE
Add numpy dependency for RAW7 image conversion

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -5,3 +5,4 @@ playwright==1.55.0
 httpx==0.27.2
 python-dateutil==2.9.0.post0
 Pillow==10.4.0
+numpy==1.26.4


### PR DESCRIPTION
The png_bytes_to_raw7 function requires numpy for image conversion. Added numpy to requirements.txt alongside Pillow to fully support RAW7 generation.