### PR TITLE
Add delay and slower SPI speed for more reliable SD card initialization

### DIFF
--- a/firmware/KindDisplay/sd_manager.cpp
+++ b/firmware/KindDisplay/sd_manager.cpp
@@ -14,8 +14,11 @@ bool SDManager::begin() {
     pinMode(_csPin, OUTPUT);
     digitalWrite(_csPin, HIGH);  // CS idle high
 
-    // Initialize SD card library
-    if (!SD.begin(_csPin, SPI, 4000000)) {  // 4MHz for compatibility
+    // Small delay for SD card stabilization after SPI init
+    delay(100);
+
+    // Initialize SD card library with slower speed for better compatibility
+    if (!SD.begin(_csPin, SPI, 400000)) {  // 400kHz for initialization (slower = more reliable)
         DEBUG_PRINTLN("SD: Card mount failed or not present");
         _initialized = false;
         return false;


### PR DESCRIPTION
- Added 100ms delay after SPI.begin() for card stabilization
- Reduced SPI speed from 4MHz to 400kHz during initialization
- 400kHz is industry standard for SD init (more compatible with cards)

This should improve reliability with various SD card types and brands.