### PR TITLE
Fix RAW7 streaming URL handling

### DIFF
--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -35,9 +35,14 @@ monitor_filters =
 build_flags =
     -D CORE_DEBUG_LEVEL=3
     -D CONFIG_ARDUHAL_LOG_COLORS=1
-    -D BOARD_HAS_PSRAM
+    ; Increase main task stack size for HTTPS/TLS operations
+    ; Default is 8192, we need more for TLS handshake + streaming callbacks
+    -D CONFIG_ARDUINO_LOOP_STACK_SIZE=16384
+    ; Disable PSRAM since we don't have it on ESP32-S
+    ; -D BOARD_HAS_PSRAM
 
-board_build.psram = enabled
+; Disable PSRAM (we don't have it on ESP32-S modules)
+; board_build.psram = enabled
 
 ; Library dependencies
 lib_deps =


### PR DESCRIPTION
- Increase main task stack from 8KB to 16KB for HTTPS/TLS operations
- TLS handshake (ECDSA crypto) + streaming callbacks need more stack
- Disable PSRAM flags since ESP32-S module doesn't have PSRAM
- Fixes 'Stack canary watchpoint triggered' crash during image download