### PR TITLE
Increase stack size to 24KB for HTTPS TLS handshake

### DIFF
--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -36,8 +36,9 @@ build_flags =
     -D CORE_DEBUG_LEVEL=3
     -D CONFIG_ARDUHAL_LOG_COLORS=1
     ; Increase main task stack size for HTTPS/TLS operations
-    ; Default is 8192, we need more for TLS handshake + streaming callbacks
-    -D CONFIG_ARDUINO_LOOP_STACK_SIZE=16384
+    ; Default is 8192, HTTPS TLS needs much more on ESP32 without PSRAM
+    ; TLS handshake alone uses ~10-12KB + our streaming callbacks
+    -D CONFIG_ARDUINO_LOOP_STACK_SIZE=24576
     ; Disable PSRAM since we don't have it on ESP32-S
     ; -D BOARD_HAS_PSRAM
 


### PR DESCRIPTION
ESP32 without PSRAM needs significant stack for TLS operations:
- TLS/HTTPS handshake: ~10-12KB (ECDSA crypto is stack-intensive)
- Streaming callbacks and buffers: ~2-3KB
- Other operations: ~5KB headroom

Total: 24KB should be sufficient even for complex TLS cipher suites.

Previous: 16KB (still crashed)
Current: 24KB