### PR TITLE
Fix stack overflow during HTTPS/TLS handshake with dedicated task

### DIFF
--- a/firmware/KindDisplay/flash_cache.cpp
+++ b/firmware/KindDisplay/flash_cache.cpp
@@ -1,5 +1,6 @@
 #include "flash_cache.h"
 #include "raw7_decoder.h"
+#include "http_task.h"
 
 // Flash cache file path
 #define FLASH_CACHE_FILE "/last.raw7"
@@ -79,6 +80,7 @@ bool FlashCache::downloadRaw7ToCache(RAW7Decoder& decoder,
     }
 
     DEBUG_PRINTLN("Flash: Streaming RAW7 download directly to cache");
+    DEBUG_PRINTLN("Flash: Running HTTPS in dedicated task with 64KB stack to avoid overflow");
 
     // Use temporary file for safe cache update
     const char* tempFile = "/last.raw7.tmp";
@@ -88,43 +90,53 @@ bool FlashCache::downloadRaw7ToCache(RAW7Decoder& decoder,
         SPIFFS.remove(tempFile);
     }
 
-    // Open temp file for writing
-    File cacheFile = SPIFFS.open(tempFile, FILE_WRITE);
-    if (!cacheFile) {
-        DEBUG_PRINTLN("Flash: Failed to open temp file for writing");
+    // Run the HTTPS download in a dedicated task with large stack
+    // This avoids stack overflow during TLS handshake on ESP32 without PSRAM
+    bool downloadSuccess = HttpTask::runWithLargeStack([&]() -> bool {
+        // Open temp file for writing
+        File cacheFile = SPIFFS.open(tempFile, FILE_WRITE);
+        if (!cacheFile) {
+            DEBUG_PRINTLN("Flash: Failed to open temp file for writing");
+            return false;
+        }
+
+        // Set up download context
+        DownloadContext ctx;
+        ctx.file = &cacheFile;
+        ctx.totalWritten = 0;
+
+        // Execute HTTPS download (TLS handshake happens here)
+        bool success = decoder.streamImage(backendUrl, deviceName, downloadChunkCallback, &ctx);
+
+        cacheFile.close();
+
+        if (success && ctx.totalWritten == RAW7_SIZE) {
+            DEBUG_PRINTF("Flash: Successfully downloaded %d bytes to temp file\n", ctx.totalWritten);
+            return true;
+        } else {
+            DEBUG_PRINTF("Flash: Download incomplete - wrote %d of %d bytes\n",
+                        ctx.totalWritten, RAW7_SIZE);
+            SPIFFS.remove(tempFile);  // Remove incomplete temp file
+            return false;
+        }
+    });
+
+    if (!downloadSuccess) {
+        DEBUG_PRINTLN("Flash: Download task failed");
         return false;
     }
 
-    // Set up download context
-    DownloadContext ctx;
-    ctx.file = &cacheFile;
-    ctx.totalWritten = 0;
+    // Atomic replace: remove old cache and rename temp to cache
+    if (SPIFFS.exists(FLASH_CACHE_FILE)) {
+        SPIFFS.remove(FLASH_CACHE_FILE);
+    }
 
-    bool success =
-        decoder.streamImage(backendUrl, deviceName, downloadChunkCallback, &ctx);
-
-    cacheFile.close();
-
-    if (success && ctx.totalWritten == RAW7_SIZE) {
-        DEBUG_PRINTF("Flash: Successfully downloaded %d bytes to temp file\n", ctx.totalWritten);
-
-        // Atomic replace: remove old cache and rename temp to cache
-        if (SPIFFS.exists(FLASH_CACHE_FILE)) {
-            SPIFFS.remove(FLASH_CACHE_FILE);
-        }
-
-        if (SPIFFS.rename(tempFile, FLASH_CACHE_FILE)) {
-            DEBUG_PRINTLN("Flash: Cache updated successfully");
-            return true;
-        } else {
-            DEBUG_PRINTLN("Flash: Failed to rename temp file to cache");
-            SPIFFS.remove(tempFile);
-            return false;
-        }
+    if (SPIFFS.rename(tempFile, FLASH_CACHE_FILE)) {
+        DEBUG_PRINTLN("Flash: Cache updated successfully");
+        return true;
     } else {
-        DEBUG_PRINTF("Flash: Download incomplete - wrote %d of %d bytes\n",
-                    ctx.totalWritten, RAW7_SIZE);
-        SPIFFS.remove(tempFile);  // Remove incomplete temp file
+        DEBUG_PRINTLN("Flash: Failed to rename temp file to cache");
+        SPIFFS.remove(tempFile);
         return false;
     }
 }

--- a/firmware/KindDisplay/http_task.cpp
+++ b/firmware/KindDisplay/http_task.cpp
@@ -1,0 +1,61 @@
+#include "http_task.h"
+
+void HttpTask::taskFunction(void* parameter) {
+    TaskContext* ctx = (TaskContext*)parameter;
+
+    if (ctx && ctx->operation) {
+        ctx->result = ctx->operation();
+    }
+
+    ctx->completed = true;
+    xSemaphoreGive(ctx->semaphore);
+
+    // Task deletes itself
+    vTaskDelete(NULL);
+}
+
+bool HttpTask::runWithLargeStack(std::function<bool()> httpOperation, uint32_t stackSize) {
+    TaskContext ctx;
+    ctx.operation = httpOperation;
+    ctx.result = false;
+    ctx.completed = false;
+    ctx.semaphore = xSemaphoreCreateBinary();
+
+    if (!ctx.semaphore) {
+        DEBUG_PRINTLN("HttpTask: Failed to create semaphore");
+        return false;
+    }
+
+    // Create task with large stack on core 0 (protocol stack runs on core 0)
+    TaskHandle_t taskHandle = NULL;
+    BaseType_t created = xTaskCreatePinnedToCore(
+        taskFunction,           // Task function
+        "http_task",           // Task name
+        stackSize / 4,         // Stack size in words (not bytes!)
+        &ctx,                  // Parameters
+        5,                     // Priority (higher than loop task)
+        &taskHandle,           // Task handle
+        0                      // Core 0 (WiFi/protocol stack)
+    );
+
+    if (created != pdPASS) {
+        DEBUG_PRINTLN("HttpTask: Failed to create task");
+        vSemaphoreDelete(ctx.semaphore);
+        return false;
+    }
+
+    DEBUG_PRINTF("HttpTask: Created task with %d bytes stack\n", stackSize);
+
+    // Wait for task to complete (max 2 minutes for slow HTTPS connections)
+    BaseType_t taken = xSemaphoreTake(ctx.semaphore, pdMS_TO_TICKS(120000));
+
+    vSemaphoreDelete(ctx.semaphore);
+
+    if (taken != pdTRUE) {
+        DEBUG_PRINTLN("HttpTask: Task timeout");
+        return false;
+    }
+
+    DEBUG_PRINTF("HttpTask: Completed with result=%d\n", ctx.result);
+    return ctx.result;
+}

--- a/firmware/KindDisplay/http_task.h
+++ b/firmware/KindDisplay/http_task.h
@@ -1,0 +1,32 @@
+#ifndef HTTP_TASK_H
+#define HTTP_TASK_H
+
+#include <Arduino.h>
+#include <functional>
+
+// ============================================================
+// HTTP Task Manager - Dedicated Stack for HTTPS Operations
+// ============================================================
+// Runs HTTP/HTTPS operations in a dedicated FreeRTOS task
+// with a large stack to avoid overflow during TLS handshake
+// ============================================================
+
+class HttpTask {
+public:
+    // Run a function in a dedicated task with large stack (64KB)
+    // This avoids stack overflow issues with HTTPS/TLS on main task
+    static bool runWithLargeStack(std::function<bool()> httpOperation,
+                                   uint32_t stackSize = 65536);
+
+private:
+    struct TaskContext {
+        std::function<bool()> operation;
+        bool result;
+        bool completed;
+        SemaphoreHandle_t semaphore;
+    };
+
+    static void taskFunction(void* parameter);
+};
+
+#endif // HTTP_TASK_H

--- a/firmware/KindDisplay/sd_manager.cpp
+++ b/firmware/KindDisplay/sd_manager.cpp
@@ -1,6 +1,7 @@
 #include "sd_manager.h"
 #include "memory_utils.h"
 #include "raw7_decoder.h"
+#include "http_task.h"
 
 SDManager::SDManager() : _initialized(false), _csPin(PIN_SD_CS) {
 }
@@ -259,6 +260,7 @@ bool SDManager::downloadRaw7ToCache(RAW7Decoder& decoder,
     }
 
     DEBUG_PRINTLN("SD: Streaming RAW7 download directly to cache");
+    DEBUG_PRINTLN("SD: Running HTTPS in dedicated task with 64KB stack to avoid overflow");
 
     // Use temporary file for safe cache update
     const char* tempFile = "/last.raw7.tmp";
@@ -268,43 +270,53 @@ bool SDManager::downloadRaw7ToCache(RAW7Decoder& decoder,
         SD.remove(tempFile);
     }
 
-    // Open temp file for writing
-    File cacheFile = SD.open(tempFile, FILE_WRITE);
-    if (!cacheFile) {
-        DEBUG_PRINTLN("SD: Failed to open temp file for writing");
+    // Run the HTTPS download in a dedicated task with large stack
+    // This avoids stack overflow during TLS handshake on ESP32 without PSRAM
+    bool downloadSuccess = HttpTask::runWithLargeStack([&]() -> bool {
+        // Open temp file for writing
+        File cacheFile = SD.open(tempFile, FILE_WRITE);
+        if (!cacheFile) {
+            DEBUG_PRINTLN("SD: Failed to open temp file for writing");
+            return false;
+        }
+
+        // Set up download context
+        DownloadContext ctx;
+        ctx.file = &cacheFile;
+        ctx.totalWritten = 0;
+
+        // Execute HTTPS download (TLS handshake happens here)
+        bool success = decoder.streamImage(backendUrl, deviceName, downloadChunkCallback, &ctx);
+
+        cacheFile.close();
+
+        if (success && ctx.totalWritten == RAW7_SIZE) {
+            DEBUG_PRINTF("SD: Successfully downloaded %d bytes to temp file\n", ctx.totalWritten);
+            return true;
+        } else {
+            DEBUG_PRINTF("SD: Download incomplete - wrote %d of %d bytes\n",
+                        ctx.totalWritten, RAW7_SIZE);
+            SD.remove(tempFile);  // Remove incomplete temp file
+            return false;
+        }
+    });
+
+    if (!downloadSuccess) {
+        DEBUG_PRINTLN("SD: Download task failed");
         return false;
     }
 
-    // Set up download context
-    DownloadContext ctx;
-    ctx.file = &cacheFile;
-    ctx.totalWritten = 0;
+    // Atomic replace: remove old cache and rename temp to cache
+    if (SD.exists(SD_CACHE_FILE)) {
+        SD.remove(SD_CACHE_FILE);
+    }
 
-    bool success =
-        decoder.streamImage(backendUrl, deviceName, downloadChunkCallback, &ctx);
-
-    cacheFile.close();
-
-    if (success && ctx.totalWritten == RAW7_SIZE) {
-        DEBUG_PRINTF("SD: Successfully downloaded %d bytes to temp file\n", ctx.totalWritten);
-
-        // Atomic replace: remove old cache and rename temp to cache
-        if (SD.exists(SD_CACHE_FILE)) {
-            SD.remove(SD_CACHE_FILE);
-        }
-
-        if (SD.rename(tempFile, SD_CACHE_FILE)) {
-            DEBUG_PRINTLN("SD: Cache updated successfully");
-            return true;
-        } else {
-            DEBUG_PRINTLN("SD: Failed to rename temp file to cache");
-            SD.remove(tempFile);
-            return false;
-        }
+    if (SD.rename(tempFile, SD_CACHE_FILE)) {
+        DEBUG_PRINTLN("SD: Cache updated successfully");
+        return true;
     } else {
-        DEBUG_PRINTF("SD: Download incomplete - wrote %d of %d bytes\n",
-                    ctx.totalWritten, RAW7_SIZE);
-        SD.remove(tempFile);  // Remove incomplete temp file
+        DEBUG_PRINTLN("SD: Failed to rename temp file to cache");
+        SD.remove(tempFile);
         return false;
     }
 }

--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -36,9 +36,13 @@ build_flags =
     -D CORE_DEBUG_LEVEL=3
     -D CONFIG_ARDUHAL_LOG_COLORS=1
     ; Increase main task stack size for HTTPS/TLS operations
-    ; Default is 8192, HTTPS TLS needs much more on ESP32 without PSRAM
-    ; TLS handshake alone uses ~10-12KB + our streaming callbacks
-    -D CONFIG_ARDUINO_LOOP_STACK_SIZE=24576
+    ; Default is 8192, but ECDSA crypto in TLS handshake needs 40-50KB on ESP32 without PSRAM
+    ; Setting to 49152 bytes (48KB) to accommodate mbedtls ECDSA operations
+    -D CONFIG_ARDUINO_LOOP_STACK_SIZE=49152
+    ; Enable ESP32 hardware crypto acceleration to reduce stack usage
+    -D CONFIG_MBEDTLS_HARDWARE_SHA=1
+    -D CONFIG_MBEDTLS_HARDWARE_AES=1
+    -D CONFIG_MBEDTLS_HARDWARE_MPI=1
     ; Disable PSRAM since we don't have it on ESP32-S
     ; -D BOARD_HAS_PSRAM
 


### PR DESCRIPTION
Problem:
- ESP32 without PSRAM experiencing stack overflow during TLS handshake
- ECDSA signature verification in mbedtls requires 30-40KB stack
- Previous 24KB stack size insufficient

Solution:
1. Increase main loop stack from 24KB to 48KB (CONFIG_ARDUINO_LOOP_STACK_SIZE=49152)
2. Enable ESP32 hardware crypto acceleration (SHA, AES, MPI) to reduce stack usage
3. Create HttpTask wrapper that runs HTTPS operations in dedicated FreeRTOS task with 64KB stack
4. Wrap all HTTPS downloads (flash_cache.cpp, sd_manager.cpp) with HttpTask

This ensures TLS handshake has guaranteed large stack, preventing watchdog triggers and boot loops during HTTPS connections to backend.