### PR TITLE
Fix background reroll HTTP 411 error by adding Content-Length header …

### DIFF
--- a/firmware/KindDisplay/raw7_decoder.cpp
+++ b/firmware/KindDisplay/raw7_decoder.cpp
@@ -153,6 +153,7 @@ bool RAW7Decoder::streamBackgroundReroll(const char* backendUrl,
 
     _http.begin(url);
     _http.setTimeout(HTTP_TIMEOUT);
+    _http.addHeader("Content-Length", "0");  // Explicitly set Content-Length for empty POST body
 
     int httpCode = _http.POST("");  // POST with empty body (device in query param)
 


### PR DESCRIPTION
…for empty POST